### PR TITLE
New "v1_replacement" format bug fix and improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# Created by .ignore support plugin (hsz.mobi)
+### C++ template
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+nbproject
+build
+UaParserTest

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -81,10 +81,10 @@ DeviceStore fill_device_store(const YAML::Node& device_parser) {
 }
 
 AgentStore fill_agent_store(const YAML::Node& node,
-    const std::string& repl,
-    const std::string& major_repl,
-    const std::string& minor_repl,
-    const std::string& patch_repl) {
+                            const std::string& repl,
+                            const std::string& major_repl,
+                            const std::string& minor_repl,
+                            const std::string& patch_repl) {
   AgentStore agent_store;
   assert(node.Type() == YAML::NodeType::Map);
   for (auto it = node.begin(); it != node.end(); ++it) {
@@ -201,10 +201,10 @@ void fill_agent(AGENT& agent, const AGENT_STORE& store, const boost::smatch& m, 
   // if ( store.replacement.empty() && m.size() > 1) {
   //   agent.family = m[1].str();
   // } else {
-  //   agent.family = store.replacement;
-  //   if ( ! store.replacementMap.empty()) {
-  //     replace_all_placeholders(agent.family,m,store.replacementMap);
-  //   }
+  //     agent.family = store.replacement;
+  //     if ( ! store.replacementMap.empty()) {
+  //       replace_all_placeholders(agent.family,m,store.replacementMap);
+  //     }
   // }
 
   if (!store.majorVersionReplacement.empty()) {
@@ -262,11 +262,11 @@ UserAgentParser::UserAgentParser(const std::string& regexes_file_path) : regexes
 }
 
 UserAgentParser::~UserAgentParser() {
-  delete static_cast<const UAStore*> (ua_store_);
+  delete static_cast<const UAStore*>(ua_store_);
 }
 
 UserAgent UserAgentParser::parse(const std::string& ua) const {
-  const auto ua_store = static_cast<const UAStore*> (ua_store_);
+  const auto ua_store = static_cast<const UAStore*>(ua_store_);
 
   try {
     const auto device = parse_device_impl(ua, ua_store);

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -18,123 +18,123 @@ namespace {
 typedef std::map<std::string::size_type, size_t> i2tuple;
 
 struct GenericStore {
-    std::string replacement;
-    i2tuple replacementMap;
-    boost::regex regExpr;
+  std::string replacement;
+  i2tuple replacementMap;
+  boost::regex regExpr;
 };
 
 struct DeviceStore : GenericStore {
-    std::string brandReplacement;
-    std::string modelReplacement;
-    i2tuple brandReplacementMap;
-    i2tuple modelReplacementMap;
+  std::string brandReplacement;
+  std::string modelReplacement;
+  i2tuple brandReplacementMap;
+  i2tuple modelReplacementMap;
 };
 
 struct AgentStore : GenericStore {
-    std::string majorVersionReplacement;
-    std::string minorVersionReplacement;
-    std::string patchVersionReplacement;
-    std::string patchMinorVersionReplacement;
+  std::string majorVersionReplacement;
+  std::string minorVersionReplacement;
+  std::string patchVersionReplacement;
+  std::string patchMinorVersionReplacement;
 };
 
 void mark_placeholders(i2tuple& replacement_map, const std::string& device_property) {
-    auto loc = device_property.rfind("$");
-    while (loc != std::string::npos) {
-        const auto replacement = device_property.substr(loc + 1, 1);
-        replacement_map[loc] = strtol(replacement.c_str(), nullptr, 10);
+  auto loc = device_property.rfind("$");
+  while (loc != std::string::npos) {
+    const auto replacement = device_property.substr(loc + 1, 1);
+    replacement_map[loc] = strtol(replacement.c_str(), nullptr, 10);
 
-        if (loc < 2)
-            break;
+    if (loc < 2)
+      break;
 
-        loc = device_property.rfind("$", loc - 2);
-    }
-    return;
+    loc = device_property.rfind("$", loc - 2);
+  }
+  return;
 }
 
 DeviceStore fill_device_store(const YAML::Node& device_parser) {
-    DeviceStore device;
-    bool regex_flag = false;
-    for (auto it = device_parser.begin(); it != device_parser.end(); ++it) {
-        const auto key = it->first.as<std::string>();
-        const auto value = it->second.as<std::string>();
-        if (key == "regex") {
-            device.regExpr.assign(value, boost::regex::optimize | boost::regex::normal);
-        } else if (key == "regex_flag" && value == "i") {
-            regex_flag = true;
-        } else if (key == "device_replacement") {
-            device.replacement = value;
-            mark_placeholders(device.replacementMap, device.replacement);
-        } else if (key == "model_replacement") {
-            device.modelReplacement = value;
-            mark_placeholders(device.modelReplacementMap, device.modelReplacement);
-        } else if (key == "brand_replacement") {
-            device.brandReplacement = value;
-            mark_placeholders(device.brandReplacementMap, device.brandReplacement);
-        } else {
-            assert(false);
-        }
+  DeviceStore device;
+  bool regex_flag = false;
+  for (auto it = device_parser.begin(); it != device_parser.end(); ++it) {
+    const auto key = it->first.as<std::string>();
+    const auto value = it->second.as<std::string>();
+    if (key == "regex") {
+      device.regExpr.assign(value, boost::regex::optimize | boost::regex::normal);
+    } else if (key == "regex_flag" && value == "i") {
+      regex_flag = true;
+    } else if (key == "device_replacement") {
+      device.replacement = value;
+      mark_placeholders(device.replacementMap, device.replacement);
+    } else if (key == "model_replacement") {
+      device.modelReplacement = value;
+      mark_placeholders(device.modelReplacementMap, device.modelReplacement);
+    } else if (key == "brand_replacement") {
+      device.brandReplacement = value;
+      mark_placeholders(device.brandReplacementMap, device.brandReplacement);
+    } else {
+      assert(false);
     }
-    if (regex_flag == true) {
-        device.regExpr.assign(device.regExpr.str(), boost::regex::optimize | boost::regex::icase | boost::regex::normal);
-    }
-    return device;
+  }
+  if (regex_flag == true) {
+    device.regExpr.assign(device.regExpr.str(), boost::regex::optimize | boost::regex::icase | boost::regex::normal);
+  }
+  return device;
 }
 
 AgentStore fill_agent_store(const YAML::Node& node,
-        const std::string& repl,
-        const std::string& major_repl,
-        const std::string& minor_repl,
-        const std::string& patch_repl) {
-    AgentStore agent_store;
-    assert(node.Type() == YAML::NodeType::Map);
-    for (auto it = node.begin(); it != node.end(); ++it) {
-        const auto key = it->first.as<std::string>();
-        const auto value = it->second.as<std::string>();
-        if (key == "regex") {
-            agent_store.regExpr.assign(value, boost::regex::optimize | boost::regex::normal);
-        } else if (key == repl) {
-            agent_store.replacement = value;
-            mark_placeholders(agent_store.replacementMap, agent_store.replacement);
-        } else if (key == major_repl && !value.empty()) {
-            agent_store.majorVersionReplacement = value;
-        } else if (key == minor_repl && !value.empty()) {
-            agent_store.minorVersionReplacement = value;
-        } else if (key == patch_repl && !value.empty()) {
-            agent_store.patchVersionReplacement = value;
-        } else {
-            assert(false);
-        }
+    const std::string& repl,
+    const std::string& major_repl,
+    const std::string& minor_repl,
+    const std::string& patch_repl) {
+  AgentStore agent_store;
+  assert(node.Type() == YAML::NodeType::Map);
+  for (auto it = node.begin(); it != node.end(); ++it) {
+    const auto key = it->first.as<std::string>();
+    const auto value = it->second.as<std::string>();
+    if (key == "regex") {
+      agent_store.regExpr.assign(value, boost::regex::optimize | boost::regex::normal);
+    } else if (key == repl) {
+      agent_store.replacement = value;
+      mark_placeholders(agent_store.replacementMap, agent_store.replacement);
+    } else if (key == major_repl && !value.empty()) {
+      agent_store.majorVersionReplacement = value;
+    } else if (key == minor_repl && !value.empty()) {
+      agent_store.minorVersionReplacement = value;
+    } else if (key == patch_repl && !value.empty()) {
+      agent_store.patchVersionReplacement = value;
+    } else {
+      assert(false);
     }
-    return agent_store;
+  }
+  return agent_store;
 }
 
 struct UAStore {
-    explicit UAStore(const std::string& regexes_file_path) {
-        auto regexes = YAML::LoadFile(regexes_file_path);
+  explicit UAStore(const std::string& regexes_file_path) {
+    auto regexes = YAML::LoadFile(regexes_file_path);
 
-        const auto& user_agent_parsers = regexes["user_agent_parsers"];
-        for (const auto& user_agent : user_agent_parsers) {
-            const auto browser =
-                    fill_agent_store(user_agent, "family_replacement", "v1_replacement", "v2_replacement", "v3_replacement");
-            browserStore.push_back(browser);
-        }
-
-        const auto& os_parsers = regexes["os_parsers"];
-        for (const auto& o : os_parsers) {
-            const auto os =
-                    fill_agent_store(o, "os_replacement", "os_v1_replacement", "os_v2_replacement", "os_v3_replacement");
-            osStore.push_back(os);
-        }
-
-        const auto& device_parsers = regexes["device_parsers"];
-        for (const auto& device_parser : device_parsers) {
-            deviceStore.push_back(fill_device_store(device_parser));
-        }
+    const auto& user_agent_parsers = regexes["user_agent_parsers"];
+    for (const auto& user_agent : user_agent_parsers) {
+      const auto browser =
+          fill_agent_store(user_agent, "family_replacement", "v1_replacement", "v2_replacement", "v3_replacement");
+      browserStore.push_back(browser);
     }
 
-    std::vector<DeviceStore> deviceStore;
-    std::vector<AgentStore> osStore;
-    std::vector<AgentStore> browserStore;
+    const auto& os_parsers = regexes["os_parsers"];
+    for (const auto& o : os_parsers) {
+      const auto os =
+          fill_agent_store(o, "os_replacement", "os_v1_replacement", "os_v2_replacement", "os_v3_replacement");
+      osStore.push_back(os);
+    }
+
+    const auto& device_parsers = regexes["device_parsers"];
+    for (const auto& device_parser : device_parsers) {
+      deviceStore.push_back(fill_device_store(device_parser));
+    }
+  }
+
+  std::vector<DeviceStore> deviceStore;
+  std::vector<AgentStore> osStore;
+  std::vector<AgentStore> browserStore;
 };
 
 /////////////
@@ -142,179 +142,179 @@ struct UAStore {
 /////////////
 
 void replace_all_placeholders(std::string& ua_property, const boost::smatch& result, const i2tuple& replacement_map) {
-    for (auto iter = replacement_map.rbegin(); iter != replacement_map.rend(); ++iter) {
-        ua_property.replace(iter->first, 2, result[iter->second].str());
-    }
-    boost::algorithm::trim(ua_property);
-    return;
+  for (auto iter = replacement_map.rbegin(); iter != replacement_map.rend(); ++iter) {
+    ua_property.replace(iter->first, 2, result[iter->second].str());
+  }
+  boost::algorithm::trim(ua_property);
+  return;
 }
 
 Device parse_device_impl(const std::string& ua, const UAStore* ua_store) {
-    Device device;
+  Device device;
 
-    for (const auto& d : ua_store->deviceStore) {
-        boost::smatch m;
+  for (const auto& d : ua_store->deviceStore) {
+    boost::smatch m;
 
-        if (boost::regex_search(ua, m, d.regExpr)) {
-            if (d.replacement.empty() && m.size() > 1) {
-                device.family = m[1].str();
-            } else {
-                device.family = d.replacement;
-                if (!d.replacementMap.empty()) {
-                    replace_all_placeholders(device.family, m, d.replacementMap);
-                }
-            }
-
-            if (!d.brandReplacement.empty()) {
-                device.brand = d.brandReplacement;
-                if (!d.brandReplacementMap.empty()) {
-                    replace_all_placeholders(device.brand, m, d.brandReplacementMap);
-                }
-            }
-            if (d.modelReplacement.empty() && m.size() > 1) {
-                device.model = m[1].str();
-            } else {
-                device.model = d.modelReplacement;
-                if (!d.modelReplacementMap.empty()) {
-                    replace_all_placeholders(device.model, m, d.modelReplacementMap);
-                }
-            }
-            break;
+    if (boost::regex_search(ua, m, d.regExpr)) {
+      if (d.replacement.empty() && m.size() > 1) {
+        device.family = m[1].str();
+      } else {
+        device.family = d.replacement;
+        if (!d.replacementMap.empty()) {
+          replace_all_placeholders(device.family, m, d.replacementMap);
         }
-    }
+      }
 
-    return device;
+      if (!d.brandReplacement.empty()) {
+        device.brand = d.brandReplacement;
+        if (!d.brandReplacementMap.empty()) {
+          replace_all_placeholders(device.brand, m, d.brandReplacementMap);
+        }
+      }
+      if (d.modelReplacement.empty() && m.size() > 1) {
+        device.model = m[1].str();
+      } else {
+        device.model = d.modelReplacement;
+        if (!d.modelReplacementMap.empty()) {
+          replace_all_placeholders(device.model, m, d.modelReplacementMap);
+        }
+      }
+      break;
+    }
+  }
+
+  return device;
 }
 
 template <class AGENT, class AGENT_STORE>
 void fill_agent(AGENT& agent, const AGENT_STORE& store, const boost::smatch& m, const bool os) {
-    if (m.size() > 1) {
-        agent.family =
-                !store.replacement.empty() ? boost::regex_replace(store.replacement, boost::regex("\\$1"), m[1].str()) : m[1];
-    } else {
-        agent.family =
-                !store.replacement.empty() ? boost::regex_replace(store.replacement, boost::regex("\\$1"), m[0].str()) : m[0];
-    }
-    boost::algorithm::trim(agent.family);
+  if (m.size() > 1) {
+    agent.family =
+        !store.replacement.empty() ? boost::regex_replace(store.replacement, boost::regex("\\$1"), m[1].str()) : m[1];
+  } else {
+    agent.family =
+        !store.replacement.empty() ? boost::regex_replace(store.replacement, boost::regex("\\$1"), m[0].str()) : m[0];
+  }
+  boost::algorithm::trim(agent.family);
 
-    // The chunk above is slightly faster than the one below.
-    // if ( store.replacement.empty() && m.size() > 1) {
-    //   agent.family = m[1].str();
-    // } else {
-    //     agent.family = store.replacement;
-    //     if ( ! store.replacementMap.empty()) {
-    //       replace_all_placeholders(agent.family,m,store.replacementMap);
-    //     }
-    // }
+  // The chunk above is slightly faster than the one below.
+  // if ( store.replacement.empty() && m.size() > 1) {
+  //   agent.family = m[1].str();
+  // } else {
+  //   agent.family = store.replacement;
+  //   if ( ! store.replacementMap.empty()) {
+  //     replace_all_placeholders(agent.family,m,store.replacementMap);
+  //   }
+  // }
 
-    if (!store.majorVersionReplacement.empty()) {
-        agent.major = boost::regex_replace(store.majorVersionReplacement, boost::regex("\\$1"), m[1].str());
-    } else if (m.size() > 2) {
-        agent.major = m[2].str();
-    }
-    if (!store.minorVersionReplacement.empty()) {
-        agent.minor = store.minorVersionReplacement;
-    } else if (m.size() > 3) {
-        agent.minor = m[3].str();
-    }
-    if (!store.patchVersionReplacement.empty()) {
-        agent.patch = store.patchVersionReplacement;
-    } else if (m.size() > 4) {
-        agent.patch = m[4].str();
-    }
-    if (os && m.size() > 5) {
-        agent.patch_minor = m[5].str();
-    }
+  if (!store.majorVersionReplacement.empty()) {
+    agent.major = boost::regex_replace(store.majorVersionReplacement, boost::regex("\\$1"), m[1].str());
+  } else if (m.size() > 2) {
+    agent.major = m[2].str();
+  }
+  if (!store.minorVersionReplacement.empty()) {
+    agent.minor = store.minorVersionReplacement;
+  } else if (m.size() > 3) {
+    agent.minor = m[3].str();
+  }
+  if (!store.patchVersionReplacement.empty()) {
+    agent.patch = store.patchVersionReplacement;
+  } else if (m.size() > 4) {
+    agent.patch = m[4].str();
+  }
+  if (os && m.size() > 5) {
+    agent.patch_minor = m[5].str();
+  }
 }
 
 Agent parse_browser_impl(const std::string& ua, const UAStore* ua_store) {
-    Agent browser;
+  Agent browser;
 
-    for (const auto& b : ua_store->browserStore) {
-        boost::smatch m;
-        if (boost::regex_search(ua, m, b.regExpr)) {
-            fill_agent(browser, b, m, false);
-            break;
-        }
+  for (const auto& b : ua_store->browserStore) {
+    boost::smatch m;
+    if (boost::regex_search(ua, m, b.regExpr)) {
+      fill_agent(browser, b, m, false);
+      break;
     }
+  }
 
-    return browser;
+  return browser;
 }
 
 Agent parse_os_impl(const std::string& ua, const UAStore* ua_store) {
-    Agent os;
+  Agent os;
 
-    for (const auto& o : ua_store->osStore) {
-        boost::smatch m;
-        if (boost::regex_search(ua, m, o.regExpr)) {
-            fill_agent(os, o, m, true);
-            break;
-        }
+  for (const auto& o : ua_store->osStore) {
+    boost::smatch m;
+    if (boost::regex_search(ua, m, o.regExpr)) {
+      fill_agent(os, o, m, true);
+      break;
     }
+  }
 
-    return os;
+  return os;
 }
 
 } // namespace
 
 UserAgentParser::UserAgentParser(const std::string& regexes_file_path) : regexes_file_path_{regexes_file_path} {
-    ua_store_ = new UAStore(regexes_file_path);
+  ua_store_ = new UAStore(regexes_file_path);
 }
 
 UserAgentParser::~UserAgentParser() {
-    delete static_cast<const UAStore*> (ua_store_);
+  delete static_cast<const UAStore*> (ua_store_);
 }
 
 UserAgent UserAgentParser::parse(const std::string& ua) const {
-    const auto ua_store = static_cast<const UAStore*> (ua_store_);
+  const auto ua_store = static_cast<const UAStore*> (ua_store_);
 
-    try {
-        const auto device = parse_device_impl(ua, ua_store);
-        const auto os = parse_os_impl(ua, ua_store);
-        const auto browser = parse_browser_impl(ua, ua_store);
-        return {device, os, browser};
-    } catch (...) {
-        return {Device(), Agent(), Agent()};
-    }
+  try {
+    const auto device = parse_device_impl(ua, ua_store);
+    const auto os = parse_os_impl(ua, ua_store);
+    const auto browser = parse_browser_impl(ua, ua_store);
+    return {device, os, browser};
+  } catch (...) {
+    return {Device(), Agent(), Agent()};
+  }
 }
 
 Device UserAgentParser::parse_device(const std::string& ua) const {
-    try {
-        return parse_device_impl(ua, static_cast<const UAStore*> (ua_store_));
-    } catch (...) {
-        return Device();
-    }
+  try {
+    return parse_device_impl(ua, static_cast<const UAStore*> (ua_store_));
+  } catch (...) {
+    return Device();
+  }
 }
 
 Agent UserAgentParser::parse_os(const std::string& ua) const {
-    try {
-        return parse_os_impl(ua, static_cast<const UAStore*> (ua_store_));
-    } catch (...) {
-        return Agent();
-    }
+  try {
+    return parse_os_impl(ua, static_cast<const UAStore*> (ua_store_));
+  } catch (...) {
+    return Agent();
+  }
 }
 
 Agent UserAgentParser::parse_browser(const std::string& ua) const {
-    try {
-        return parse_browser_impl(ua, static_cast<const UAStore*> (ua_store_));
-    } catch (...) {
-        return Agent();
-    }
+  try {
+    return parse_browser_impl(ua, static_cast<const UAStore*> (ua_store_));
+  } catch (...) {
+    return Agent();
+  }
 }
 
 DeviceType UserAgentParser::device_type(const std::string& ua) const {
-    // https://gist.github.com/dalethedeveloper/1503252/931cc8b613aaa930ef92a4027916e6687d07feac
-    static boost::regex rx_mob("Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune", boost::regex::optimize | boost::regex::normal);
-    static boost::regex rx_tabl("(tablet|ipad|playbook|silk)|(android(?!.*mobile))", boost::regex::icase | boost::regex::optimize | boost::regex::normal);
-    boost::smatch m;
-    try {
-        if (boost::regex_search(ua, m, rx_tabl)) {
-            return DeviceType::kTablet;
-        } else if (boost::regex_search(ua, m, rx_mob)) {
-            return DeviceType::kMobile;
-        }
-        return DeviceType::kDesktop;
-    } catch (...) {
-        return DeviceType::kUnknown;
+  // https://gist.github.com/dalethedeveloper/1503252/931cc8b613aaa930ef92a4027916e6687d07feac
+  static boost::regex rx_mob("Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune", boost::regex::optimize | boost::regex::normal);
+  static boost::regex rx_tabl("(tablet|ipad|playbook|silk)|(android(?!.*mobile))", boost::regex::icase | boost::regex::optimize | boost::regex::normal);
+  boost::smatch m;
+  try {
+    if (boost::regex_search(ua, m, rx_tabl)) {
+      return DeviceType::kTablet;
+    } else if (boost::regex_search(ua, m, rx_mob)) {
+      return DeviceType::kMobile;
     }
+    return DeviceType::kDesktop;
+  } catch (...) {
+    return DeviceType::kUnknown;
+  }
 }

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -255,7 +255,7 @@ Agent parse_os_impl(const std::string& ua, const UAStore* ua_store) {
   return os;
 }
 
-} // namespace
+}  // namespace
 
 UserAgentParser::UserAgentParser(const std::string& regexes_file_path) : regexes_file_path_{regexes_file_path} {
   ua_store_ = new UAStore(regexes_file_path);

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -11,128 +11,130 @@
 #include <boost/algorithm/string.hpp>
 #include <yaml-cpp/yaml.h>
 
+using namespace uap_cpp;
+
 namespace {
 
 typedef std::map<std::string::size_type, size_t> i2tuple;
 
 struct GenericStore {
-  std::string replacement;
-  i2tuple replacementMap;
-  boost::regex regExpr;
+    std::string replacement;
+    i2tuple replacementMap;
+    boost::regex regExpr;
 };
 
 struct DeviceStore : GenericStore {
-  std::string brandReplacement;
-  std::string modelReplacement;
-  i2tuple brandReplacementMap;
-  i2tuple modelReplacementMap;
+    std::string brandReplacement;
+    std::string modelReplacement;
+    i2tuple brandReplacementMap;
+    i2tuple modelReplacementMap;
 };
 
 struct AgentStore : GenericStore {
-  std::string majorVersionReplacement;
-  std::string minorVersionReplacement;
-  std::string patchVersionReplacement;
-  std::string patchMinorVersionReplacement;
+    std::string majorVersionReplacement;
+    std::string minorVersionReplacement;
+    std::string patchVersionReplacement;
+    std::string patchMinorVersionReplacement;
 };
 
 void mark_placeholders(i2tuple& replacement_map, const std::string& device_property) {
-  auto loc = device_property.rfind("$");
-  while (loc != std::string::npos) {
-    const auto replacement = device_property.substr(loc + 1, 1);
-    replacement_map[loc] = strtol(replacement.c_str(), nullptr, 10);
+    auto loc = device_property.rfind("$");
+    while (loc != std::string::npos) {
+        const auto replacement = device_property.substr(loc + 1, 1);
+        replacement_map[loc] = strtol(replacement.c_str(), nullptr, 10);
 
-    if (loc < 2)
-      break;
+        if (loc < 2)
+            break;
 
-    loc = device_property.rfind("$", loc - 2);
-  }
-  return;
+        loc = device_property.rfind("$", loc - 2);
+    }
+    return;
 }
 
 DeviceStore fill_device_store(const YAML::Node& device_parser) {
-  DeviceStore device;
-  bool regex_flag = false;
-  for (auto it = device_parser.begin(); it != device_parser.end(); ++it) {
-    const auto key = it->first.as<std::string>();
-    const auto value = it->second.as<std::string>();
-    if (key == "regex") {
-      device.regExpr.assign(value, boost::regex::optimize | boost::regex::normal);
-    } else if (key == "regex_flag" && value == "i") {
-      regex_flag = true;
-    } else if (key == "device_replacement") {
-      device.replacement = value;
-      mark_placeholders(device.replacementMap, device.replacement);
-    } else if (key == "model_replacement") {
-      device.modelReplacement = value;
-      mark_placeholders(device.modelReplacementMap, device.modelReplacement);
-    } else if (key == "brand_replacement") {
-      device.brandReplacement = value;
-      mark_placeholders(device.brandReplacementMap, device.brandReplacement);
-    } else {
-      assert(false);
+    DeviceStore device;
+    bool regex_flag = false;
+    for (auto it = device_parser.begin(); it != device_parser.end(); ++it) {
+        const auto key = it->first.as<std::string>();
+        const auto value = it->second.as<std::string>();
+        if (key == "regex") {
+            device.regExpr.assign(value, boost::regex::optimize | boost::regex::normal);
+        } else if (key == "regex_flag" && value == "i") {
+            regex_flag = true;
+        } else if (key == "device_replacement") {
+            device.replacement = value;
+            mark_placeholders(device.replacementMap, device.replacement);
+        } else if (key == "model_replacement") {
+            device.modelReplacement = value;
+            mark_placeholders(device.modelReplacementMap, device.modelReplacement);
+        } else if (key == "brand_replacement") {
+            device.brandReplacement = value;
+            mark_placeholders(device.brandReplacementMap, device.brandReplacement);
+        } else {
+            assert(false);
+        }
     }
-  }
-  if (regex_flag == true) {
-    device.regExpr.assign(device.regExpr.str(), boost::regex::optimize | boost::regex::icase | boost::regex::normal);
-  }
-  return device;
+    if (regex_flag == true) {
+        device.regExpr.assign(device.regExpr.str(), boost::regex::optimize | boost::regex::icase | boost::regex::normal);
+    }
+    return device;
 }
 
 AgentStore fill_agent_store(const YAML::Node& node,
-                            const std::string& repl,
-                            const std::string& major_repl,
-                            const std::string& minor_repl,
-                            const std::string& patch_repl) {
-  AgentStore agent_store;
-  assert(node.Type() == YAML::NodeType::Map);
-  for (auto it = node.begin(); it != node.end(); ++it) {
-    const auto key = it->first.as<std::string>();
-    const auto value = it->second.as<std::string>();
-    if (key == "regex") {
-      agent_store.regExpr.assign(value, boost::regex::optimize | boost::regex::normal);
-    } else if (key == repl) {
-      agent_store.replacement = value;
-      mark_placeholders(agent_store.replacementMap, agent_store.replacement);
-    } else if (key == major_repl && !value.empty()) {
-      agent_store.majorVersionReplacement = value;
-    } else if (key == minor_repl && !value.empty()) {
-      agent_store.minorVersionReplacement = value;
-    } else if (key == patch_repl && !value.empty()) {
-      agent_store.patchVersionReplacement = value;
-    } else {
-      assert(false);
+        const std::string& repl,
+        const std::string& major_repl,
+        const std::string& minor_repl,
+        const std::string& patch_repl) {
+    AgentStore agent_store;
+    assert(node.Type() == YAML::NodeType::Map);
+    for (auto it = node.begin(); it != node.end(); ++it) {
+        const auto key = it->first.as<std::string>();
+        const auto value = it->second.as<std::string>();
+        if (key == "regex") {
+            agent_store.regExpr.assign(value, boost::regex::optimize | boost::regex::normal);
+        } else if (key == repl) {
+            agent_store.replacement = value;
+            mark_placeholders(agent_store.replacementMap, agent_store.replacement);
+        } else if (key == major_repl && !value.empty()) {
+            agent_store.majorVersionReplacement = value;
+        } else if (key == minor_repl && !value.empty()) {
+            agent_store.minorVersionReplacement = value;
+        } else if (key == patch_repl && !value.empty()) {
+            agent_store.patchVersionReplacement = value;
+        } else {
+            assert(false);
+        }
     }
-  }
-  return agent_store;
+    return agent_store;
 }
 
 struct UAStore {
-  explicit UAStore(const std::string& regexes_file_path) {
-    auto regexes = YAML::LoadFile(regexes_file_path);
+    explicit UAStore(const std::string& regexes_file_path) {
+        auto regexes = YAML::LoadFile(regexes_file_path);
 
-    const auto& user_agent_parsers = regexes["user_agent_parsers"];
-    for (const auto& user_agent : user_agent_parsers) {
-      const auto browser =
-          fill_agent_store(user_agent, "family_replacement", "v1_replacement", "v2_replacement", "v3_replacement");
-      browserStore.push_back(browser);
+        const auto& user_agent_parsers = regexes["user_agent_parsers"];
+        for (const auto& user_agent : user_agent_parsers) {
+            const auto browser =
+                    fill_agent_store(user_agent, "family_replacement", "v1_replacement", "v2_replacement", "v3_replacement");
+            browserStore.push_back(browser);
+        }
+
+        const auto& os_parsers = regexes["os_parsers"];
+        for (const auto& o : os_parsers) {
+            const auto os =
+                    fill_agent_store(o, "os_replacement", "os_v1_replacement", "os_v2_replacement", "os_v3_replacement");
+            osStore.push_back(os);
+        }
+
+        const auto& device_parsers = regexes["device_parsers"];
+        for (const auto& device_parser : device_parsers) {
+            deviceStore.push_back(fill_device_store(device_parser));
+        }
     }
 
-    const auto& os_parsers = regexes["os_parsers"];
-    for (const auto& o : os_parsers) {
-      const auto os =
-          fill_agent_store(o, "os_replacement", "os_v1_replacement", "os_v2_replacement", "os_v3_replacement");
-      osStore.push_back(os);
-    }
-
-    const auto& device_parsers = regexes["device_parsers"];
-    for (const auto& device_parser : device_parsers) {
-      deviceStore.push_back(fill_device_store(device_parser));
-    }
-  }
-
-  std::vector<DeviceStore> deviceStore;
-  std::vector<AgentStore> osStore;
-  std::vector<AgentStore> browserStore;
+    std::vector<DeviceStore> deviceStore;
+    std::vector<AgentStore> osStore;
+    std::vector<AgentStore> browserStore;
 };
 
 /////////////
@@ -140,141 +142,179 @@ struct UAStore {
 /////////////
 
 void replace_all_placeholders(std::string& ua_property, const boost::smatch& result, const i2tuple& replacement_map) {
-  for (auto iter = replacement_map.rbegin(); iter != replacement_map.rend(); ++iter) {
-    ua_property.replace(iter->first, 2, result[iter->second].str());
-  }
-  boost::algorithm::trim(ua_property);
-  return;
+    for (auto iter = replacement_map.rbegin(); iter != replacement_map.rend(); ++iter) {
+        ua_property.replace(iter->first, 2, result[iter->second].str());
+    }
+    boost::algorithm::trim(ua_property);
+    return;
 }
 
 Device parse_device_impl(const std::string& ua, const UAStore* ua_store) {
-  Device device;
+    Device device;
 
-  for (const auto& d : ua_store->deviceStore) {
-    boost::smatch m;
+    for (const auto& d : ua_store->deviceStore) {
+        boost::smatch m;
 
-    if (boost::regex_search(ua, m, d.regExpr)) {
-      if (d.replacement.empty() && m.size() > 1) {
-        device.family = m[1].str();
-      } else {
-        device.family = d.replacement;
-        if (!d.replacementMap.empty()) {
-          replace_all_placeholders(device.family, m, d.replacementMap);
-        }
-      }
+        if (boost::regex_search(ua, m, d.regExpr)) {
+            if (d.replacement.empty() && m.size() > 1) {
+                device.family = m[1].str();
+            } else {
+                device.family = d.replacement;
+                if (!d.replacementMap.empty()) {
+                    replace_all_placeholders(device.family, m, d.replacementMap);
+                }
+            }
 
-      if (!d.brandReplacement.empty()) {
-        device.brand = d.brandReplacement;
-        if (!d.brandReplacementMap.empty()) {
-          replace_all_placeholders(device.brand, m, d.brandReplacementMap);
+            if (!d.brandReplacement.empty()) {
+                device.brand = d.brandReplacement;
+                if (!d.brandReplacementMap.empty()) {
+                    replace_all_placeholders(device.brand, m, d.brandReplacementMap);
+                }
+            }
+            if (d.modelReplacement.empty() && m.size() > 1) {
+                device.model = m[1].str();
+            } else {
+                device.model = d.modelReplacement;
+                if (!d.modelReplacementMap.empty()) {
+                    replace_all_placeholders(device.model, m, d.modelReplacementMap);
+                }
+            }
+            break;
         }
-      }
-      if (d.modelReplacement.empty() && m.size() > 1) {
-        device.model = m[1].str();
-      } else {
-        device.model = d.modelReplacement;
-        if (!d.modelReplacementMap.empty()) {
-          replace_all_placeholders(device.model, m, d.modelReplacementMap);
-        }
-      }
-      break;
-    } else {
-      device.family = "Other";
     }
-  }
 
-  return device;
+    return device;
 }
 
 template <class AGENT, class AGENT_STORE>
 void fill_agent(AGENT& agent, const AGENT_STORE& store, const boost::smatch& m, const bool os) {
-  if (m.size() > 1) {
-    agent.family =
-        !store.replacement.empty() ? boost::regex_replace(store.replacement, boost::regex("\\$1"), m[1].str()) : m[1];
-  } else {
-    agent.family =
-        !store.replacement.empty() ? boost::regex_replace(store.replacement, boost::regex("\\$1"), m[0].str()) : m[0];
-  }
-  boost::algorithm::trim(agent.family);
+    if (m.size() > 1) {
+        agent.family =
+                !store.replacement.empty() ? boost::regex_replace(store.replacement, boost::regex("\\$1"), m[1].str()) : m[1];
+    } else {
+        agent.family =
+                !store.replacement.empty() ? boost::regex_replace(store.replacement, boost::regex("\\$1"), m[0].str()) : m[0];
+    }
+    boost::algorithm::trim(agent.family);
 
-  // The chunk above is slightly faster than the one below.
-  // if ( store.replacement.empty() && m.size() > 1) {
-  //   agent.family = m[1].str();
-  // } else {
-  //     agent.family = store.replacement;
-  //     if ( ! store.replacementMap.empty()) {
-  //       replace_all_placeholders(agent.family,m,store.replacementMap);
-  //     }
-  // }
+    // The chunk above is slightly faster than the one below.
+    // if ( store.replacement.empty() && m.size() > 1) {
+    //   agent.family = m[1].str();
+    // } else {
+    //     agent.family = store.replacement;
+    //     if ( ! store.replacementMap.empty()) {
+    //       replace_all_placeholders(agent.family,m,store.replacementMap);
+    //     }
+    // }
 
-  if (!store.majorVersionReplacement.empty()) {
-    agent.major = store.majorVersionReplacement;
-  } else if (m.size() > 2) {
-    agent.major = m[2].str();
-  }
-  if (!store.minorVersionReplacement.empty()) {
-    agent.minor = store.minorVersionReplacement;
-  } else if (m.size() > 3) {
-    agent.minor = m[3].str();
-  }
-  if (!store.patchVersionReplacement.empty()) {
-    agent.patch = store.patchVersionReplacement;
-  } else if (m.size() > 4) {
-    agent.patch = m[4].str();
-  }
-  if (os && m.size() > 5) {
-    agent.patch_minor = m[5].str();
-  }
+    if (!store.majorVersionReplacement.empty()) {
+        agent.major = boost::regex_replace(store.majorVersionReplacement, boost::regex("\\$1"), m[1].str());
+    } else if (m.size() > 2) {
+        agent.major = m[2].str();
+    }
+    if (!store.minorVersionReplacement.empty()) {
+        agent.minor = store.minorVersionReplacement;
+    } else if (m.size() > 3) {
+        agent.minor = m[3].str();
+    }
+    if (!store.patchVersionReplacement.empty()) {
+        agent.patch = store.patchVersionReplacement;
+    } else if (m.size() > 4) {
+        agent.patch = m[4].str();
+    }
+    if (os && m.size() > 5) {
+        agent.patch_minor = m[5].str();
+    }
 }
 
 Agent parse_browser_impl(const std::string& ua, const UAStore* ua_store) {
-  Agent browser;
+    Agent browser;
 
-  for (const auto& b : ua_store->browserStore) {
-    boost::smatch m;
-    if (boost::regex_search(ua, m, b.regExpr)) {
-      fill_agent(browser, b, m, false);
-      break;
-    } else {
-      browser.family = "Other";
+    for (const auto& b : ua_store->browserStore) {
+        boost::smatch m;
+        if (boost::regex_search(ua, m, b.regExpr)) {
+            fill_agent(browser, b, m, false);
+            break;
+        }
     }
-  }
 
-  return browser;
+    return browser;
 }
 
 Agent parse_os_impl(const std::string& ua, const UAStore* ua_store) {
-  Agent os;
+    Agent os;
 
-  for (const auto& o : ua_store->osStore) {
-    boost::smatch m;
-    if (boost::regex_search(ua, m, o.regExpr)) {
-      fill_agent(os, o, m, true);
-      break;
-    } else {
-      os.family = "Other";
+    for (const auto& o : ua_store->osStore) {
+        boost::smatch m;
+        if (boost::regex_search(ua, m, o.regExpr)) {
+            fill_agent(os, o, m, true);
+            break;
+        }
     }
-  }
 
-  return os;
+    return os;
 }
 
-}  // namespace
+} // namespace
 
 UserAgentParser::UserAgentParser(const std::string& regexes_file_path) : regexes_file_path_{regexes_file_path} {
-  ua_store_ = new UAStore(regexes_file_path);
+    ua_store_ = new UAStore(regexes_file_path);
 }
 
 UserAgentParser::~UserAgentParser() {
-  delete static_cast<const UAStore*>(ua_store_);
+    delete static_cast<const UAStore*> (ua_store_);
 }
 
 UserAgent UserAgentParser::parse(const std::string& ua) const {
-  const auto ua_store = static_cast<const UAStore*>(ua_store_);
+    const auto ua_store = static_cast<const UAStore*> (ua_store_);
 
-  const auto device = parse_device_impl(ua, ua_store);
-  const auto os = parse_os_impl(ua, ua_store);
-  const auto browser = parse_browser_impl(ua, ua_store);
+    try {
+        const auto device = parse_device_impl(ua, ua_store);
+        const auto os = parse_os_impl(ua, ua_store);
+        const auto browser = parse_browser_impl(ua, ua_store);
+        return {device, os, browser};
+    } catch (...) {
+        return {Device(), Agent(), Agent()};
+    }
+}
 
-  return {device, os, browser};
+Device UserAgentParser::parse_device(const std::string& ua) const {
+    try {
+        return parse_device_impl(ua, static_cast<const UAStore*> (ua_store_));
+    } catch (...) {
+        return Device();
+    }
+}
+
+Agent UserAgentParser::parse_os(const std::string& ua) const {
+    try {
+        return parse_os_impl(ua, static_cast<const UAStore*> (ua_store_));
+    } catch (...) {
+        return Agent();
+    }
+}
+
+Agent UserAgentParser::parse_browser(const std::string& ua) const {
+    try {
+        return parse_browser_impl(ua, static_cast<const UAStore*> (ua_store_));
+    } catch (...) {
+        return Agent();
+    }
+}
+
+DeviceType UserAgentParser::device_type(const std::string& ua) const {
+    // https://gist.github.com/dalethedeveloper/1503252/931cc8b613aaa930ef92a4027916e6687d07feac
+    static boost::regex rx_mob("Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune", boost::regex::optimize | boost::regex::normal);
+    static boost::regex rx_tabl("(tablet|ipad|playbook|silk)|(android(?!.*mobile))", boost::regex::icase | boost::regex::optimize | boost::regex::normal);
+    boost::smatch m;
+    try {
+        if (boost::regex_search(ua, m, rx_tabl)) {
+            return DeviceType::kTablet;
+        } else if (boost::regex_search(ua, m, rx_mob)) {
+            return DeviceType::kMobile;
+        }
+        return DeviceType::kDesktop;
+    } catch (...) {
+        return DeviceType::kUnknown;
+    }
 }

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -11,9 +11,7 @@
 #include <boost/algorithm/string.hpp>
 #include <yaml-cpp/yaml.h>
 
-using namespace uap_cpp;
-
-namespace {
+namespace uap_cpp {
 
 typedef std::map<std::string::size_type, size_t> i2tuple;
 
@@ -255,8 +253,6 @@ Agent parse_os_impl(const std::string& ua, const UAStore* ua_store) {
   return os;
 }
 
-}  // namespace
-
 UserAgentParser::UserAgentParser(const std::string& regexes_file_path) : regexes_file_path_{regexes_file_path} {
   ua_store_ = new UAStore(regexes_file_path);
 }
@@ -318,3 +314,5 @@ DeviceType UserAgentParser::device_type(const std::string& ua) const {
     return DeviceType::kUnknown;
   }
 }
+
+}  // namespace uap_cpp

--- a/UaParser.h
+++ b/UaParser.h
@@ -60,5 +60,4 @@ private:
   const std::string regexes_file_path_;
   const void* ua_store_;
 };
-
 }

--- a/UaParser.h
+++ b/UaParser.h
@@ -5,66 +5,66 @@
 namespace uap_cpp {
 
 struct Generic {
-    Generic() : family("Other") {}
-    std::string family;
+  Generic() : family("Other") {}
+  std::string family;
 };
 
 struct Device : Generic {
-    std::string model;
-    std::string brand;
+  std::string model;
+  std::string brand;
 };
 
 struct Agent : Generic {
-    std::string major;
-    std::string minor;
-    std::string patch;
-    std::string patch_minor;
+  std::string major;
+  std::string minor;
+  std::string patch;
+  std::string patch_minor;
 
-    std::string toString() const {
-        return family + " " + toVersionString();
-    }
+  std::string toString() const {
+    return family + " " + toVersionString();
+  }
 
-    std::string toVersionString() const {
-        return (major.empty() ? "0" : major) + "." + (minor.empty() ? "0" : minor) + "." + (patch.empty() ? "0" : patch);
-    }
+  std::string toVersionString() const {
+    return (major.empty() ? "0" : major) + "." + (minor.empty() ? "0" : minor) + "." + (patch.empty() ? "0" : patch);
+  }
 };
 
 struct UserAgent {
-    Device device;
+  Device device;
 
-    Agent os;
-    Agent browser;
+  Agent os;
+  Agent browser;
 
-    std::string toFullString() const {
-        return browser.toString() + "/" + os.toString();
-    }
+  std::string toFullString() const {
+    return browser.toString() + "/" + os.toString();
+  }
 
-    bool isSpider() const {
-        return device.family == "Spider";
-    }
+  bool isSpider() const {
+    return device.family == "Spider";
+  }
 };
 
 enum DeviceType {
-    kUnknown = 0, kDesktop, kMobile, kTablet
+  kUnknown = 0, kDesktop, kMobile, kTablet
 };
 
 class UserAgentParser {
 public:
-    explicit UserAgentParser(const std::string& regexes_file_path);
+  explicit UserAgentParser(const std::string& regexes_file_path);
 
-    UserAgent parse(const std::string&) const;
+  UserAgent parse(const std::string&) const;
 
-    Device parse_device(const std::string&) const;
-    Agent parse_os(const std::string&) const;
-    Agent parse_browser(const std::string&) const;
-    
-    DeviceType device_type(const std::string&) const;
+  Device parse_device(const std::string&) const;
+  Agent parse_os(const std::string&) const;
+  Agent parse_browser(const std::string&) const;
+  
+  DeviceType device_type(const std::string&) const;
 
-    ~UserAgentParser();
+  ~UserAgentParser();
 
 private:
-    const std::string regexes_file_path_;
-    const void* ua_store_;
+  const std::string regexes_file_path_;
+  const void* ua_store_;
 };
 
 }

--- a/UaParser.h
+++ b/UaParser.h
@@ -2,48 +2,69 @@
 
 #include <string>
 
+namespace uap_cpp {
+
 struct Generic {
-  std::string family;
+    Generic() : family("Other") {}
+    std::string family;
 };
 
 struct Device : Generic {
-  std::string model;
-  std::string brand;
+    std::string model;
+    std::string brand;
 };
 
 struct Agent : Generic {
-  std::string major;
-  std::string minor;
-  std::string patch;
-  std::string patch_minor;
+    std::string major;
+    std::string minor;
+    std::string patch;
+    std::string patch_minor;
 
-  std::string toString() const { return family + " " + toVersionString(); }
+    std::string toString() const {
+        return family + " " + toVersionString();
+    }
 
-  std::string toVersionString() const {
-    return (major.empty() ? "0" : major) + "." + (minor.empty() ? "0" : minor) + "." + (patch.empty() ? "0" : patch);
-  }
+    std::string toVersionString() const {
+        return (major.empty() ? "0" : major) + "." + (minor.empty() ? "0" : minor) + "." + (patch.empty() ? "0" : patch);
+    }
 };
 
 struct UserAgent {
-  Device device;
+    Device device;
 
-  Agent os;
-  Agent browser;
+    Agent os;
+    Agent browser;
 
-  std::string toFullString() const { return browser.toString() + "/" + os.toString(); }
+    std::string toFullString() const {
+        return browser.toString() + "/" + os.toString();
+    }
 
-  bool isSpider() const { return device.family == "Spider"; }
+    bool isSpider() const {
+        return device.family == "Spider";
+    }
+};
+
+enum DeviceType {
+    kUnknown = 0, kDesktop, kMobile, kTablet
 };
 
 class UserAgentParser {
- public:
-  explicit UserAgentParser(const std::string& regexes_file_path);
+public:
+    explicit UserAgentParser(const std::string& regexes_file_path);
 
-  UserAgent parse(const std::string&) const;
+    UserAgent parse(const std::string&) const;
 
-  ~UserAgentParser();
+    Device parse_device(const std::string&) const;
+    Agent parse_os(const std::string&) const;
+    Agent parse_browser(const std::string&) const;
+    
+    DeviceType device_type(const std::string&) const;
 
- private:
-  const std::string regexes_file_path_;
-  const void* ua_store_;
+    ~UserAgentParser();
+
+private:
+    const std::string regexes_file_path_;
+    const void* ua_store_;
 };
+
+}

--- a/UaParser.h
+++ b/UaParser.h
@@ -20,9 +20,7 @@ struct Agent : Generic {
   std::string patch;
   std::string patch_minor;
 
-  std::string toString() const {
-    return family + " " + toVersionString();
-  }
+  std::string toString() const { return family + " " + toVersionString(); }
 
   std::string toVersionString() const {
     return (major.empty() ? "0" : major) + "." + (minor.empty() ? "0" : minor) + "." + (patch.empty() ? "0" : patch);
@@ -35,13 +33,9 @@ struct UserAgent {
   Agent os;
   Agent browser;
 
-  std::string toFullString() const {
-    return browser.toString() + "/" + os.toString();
-  }
+  std::string toFullString() const { return browser.toString() + "/" + os.toString(); }
 
-  bool isSpider() const {
-    return device.family == "Spider";
-  }
+  bool isSpider() const { return device.family == "Spider"; }
 };
 
 enum DeviceType {

--- a/UaParser.h
+++ b/UaParser.h
@@ -60,4 +60,5 @@ private:
   const std::string regexes_file_path_;
   const void* ua_store_;
 };
-}
+
+}  // namespace uap_cpp

--- a/UaParserTest.cpp
+++ b/UaParserTest.cpp
@@ -4,6 +4,8 @@
 #include <yaml-cpp/yaml.h>
 #include <string>
 
+using namespace uap_cpp;
+
 namespace {
 
 static const std::string UA_CORE_DIR = "../uap-core";

--- a/UaParserTest.cpp
+++ b/UaParserTest.cpp
@@ -4,13 +4,9 @@
 #include <yaml-cpp/yaml.h>
 #include <string>
 
-using namespace uap_cpp;
-
-namespace {
-
 static const std::string UA_CORE_DIR = "../uap-core";
 
-const UserAgentParser g_ua_parser(UA_CORE_DIR + "/regexes.yaml");
+const uap_cpp::UserAgentParser g_ua_parser(UA_CORE_DIR + "/regexes.yaml");
 
 TEST(UserAgentParser, basic) {
   const auto uagent = g_ua_parser.parse(
@@ -36,8 +32,6 @@ TEST(UserAgentParser, basic) {
 
   ASSERT_FALSE(uagent.isSpider());
 }
-
-namespace {
 
 std::string string_field(const YAML::Node& root, const std::string& fname) {
   const auto& yaml_field = root[fname];
@@ -81,8 +75,6 @@ void test_device(const std::string file_path) {
   }
 }
 
-}  // namespace
-
 TEST(OsVersion, test_os) {
   test_browser_or_os(UA_CORE_DIR + "/tests/test_os.yaml", false);
 }
@@ -110,8 +102,6 @@ TEST(OsVersion, additional_os_tests) {
 TEST(DeviceFamily, test_device) {
   test_device(UA_CORE_DIR + "/tests/test_device.yaml");
 }
-
-}  // namespace
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
* placed code in a namespace;
* initialized "family" one time rather than on each iteration in a 
cycle;
* fixed a bug for a new "v1_replacement" format (when it equals to $1). 
Now UaParserTest.cpp passes all test with the latest regexes.yaml;
* introduced a function device_type to get a device type (desktop, 
mobile, tablet). Regexps are based on a slightly outdated info from:
https://gist.github.com/dalethedeveloper/1503252/931cc8b613aaa930ef92a4027916e6687d07feac
and require improvements;
* provided separate "parse_os", "parse_browser", "parse_device" 
functions (mostly because "parse_device" takes almost whole time 
alone and has the lowest value in most of the cases);
* handled boost:regexp exceptions properly.