### PR TITLE
Build on Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ libuaparser_cpp.so: UaParser.o
 UaParserTest: libuaparser_cpp.a UaParserTest.o
 	$(CXX) $^ -o $@ libuaparser_cpp.a $(LDFLAGS) -lgtest -lpthread
 
-test: UaParserTest
+test: UaParserTest libuaparser_cpp.so
 	./UaParserTest
 
 # clean everything generated

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
-ifndef LDFLAGS
-	LDFLAGS=-lboost_regex -lyaml-cpp
-endif
-ifndef CXXFLAGS
-	CXXFLAGS=-std=c++0x -Wall -Werror -fPIC -g -O3
-endif
+LDFLAGS += -lboost_regex -lyaml-cpp
+CXXFLAGS += -std=c++0x -Wall -Werror -g -fPIC -O3
 
 # wildcard object build target
 %.o: %.cpp
@@ -16,7 +12,7 @@ libuaparser_cpp.a: UaParser.o
 	ar rcs $@ $^
 
 libuaparser_cpp.so: UaParser.o
-	$(LD) $< -shared $(LDFLAGS) -o $@
+	$(CXX) $< -shared $(LDFLAGS) -o $@
 
 UaParserTest: libuaparser_cpp.a UaParserTest.o
 	$(CXX) $^ -o $@ libuaparser_cpp.a $(LDFLAGS) -lgtest -lpthread


### PR DESCRIPTION
I had to mess with the Makefile in order to get this to build on Arch Linux, so, here are my changes.

1. The existing code merely sets a default for the flags, whereas the flag -fPIC is actually required to get the libraries to build at all. A lot of distros like to add to the default flags in order to inject options like `-fstack-protector-strong`, so, I think that this is a more-correct behaviour.
2. In order to compile on the latest GCC, you need to link using `$(CXX)` instead of `$(LD)`. This is because the C++ objects require a bit of extra messing-with in order to form an actual, dynamic object.

This shouldn't break builds on any other systems, but it would be nice to not have to apply this patch to get the build to work on Arch.