### PR TITLE
Index text snippets in regexes to speed up user agent parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -qq libboost-regex-dev libyaml-cpp-dev cmake libgtest-dev
+- sudo apt-get install -qq libboost-regex-dev libyaml-cpp-dev cmake libgtest-dev libre2-dev
 - cd /usr/src/gtest
 - sudo cmake CMakeLists.txt
 - sudo make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: cpp
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -qq libboost-regex-dev libyaml-cpp-dev cmake libgtest-dev libre2-dev
+- sudo apt-get install -qq libyaml-cpp-dev cmake libgtest-dev libre2-dev
 - cd /usr/src/gtest
 - sudo cmake CMakeLists.txt
 - sudo make

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -5,6 +5,7 @@
 #include "internal/ReplaceTemplate.h"
 #include "internal/SnippetIndex.h"
 #include "internal/SnippetMapping.h"
+#include "internal/StringUtils.h"
 
 #include <cassert>
 #include <cstdlib>
@@ -14,7 +15,6 @@
 #include <vector>
 
 #include <yaml-cpp/yaml.h>
-#include <boost/algorithm/string.hpp>
 
 namespace {
 
@@ -193,11 +193,11 @@ uap_cpp::Device parse_device_impl(const std::string& ua,
       } else {
         device.family = d.replacement.expand(m);
       }
-      boost::algorithm::trim(device.family);
+      trim(device.family);
 
       if (!d.brandReplacement.empty()) {
         device.brand = d.brandReplacement.expand(m);
-        boost::algorithm::trim(device.brand);
+        trim(device.brand);
       }
 
       if (d.modelReplacement.empty() && m.size() > 1) {
@@ -205,7 +205,7 @@ uap_cpp::Device parse_device_impl(const std::string& ua,
       } else {
         device.model = d.modelReplacement.expand(m);
       }
-      boost::algorithm::trim(device.model);
+      trim(device.model);
 
       break;
     }
@@ -223,7 +223,7 @@ void fill_agent(AGENT& agent,
   } else {
     agent.family = store.replacement.expand(m);
   }
-  boost::algorithm::trim(agent.family);
+  trim(agent.family);
 
   if (!store.majorVersionReplacement.empty()) {
     agent.major = store.majorVersionReplacement.expand(m);

--- a/UaParser.vcxproj
+++ b/UaParser.vcxproj
@@ -153,9 +153,20 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="UaParser.h" />
+    <ClInclude Include="internal\Pattern.h" />
+    <ClInclude Include="internal\AlternativeExpander.h" />
+    <ClInclude Include="internal\SnippetIndex.h" />
+    <ClInclude Include="internal\SnippetMapping.h" />
+    <ClInclude Include="internal\ReplaceTemplate.h" />
+    <ClInclude Include="internal\StringUtils.h" />
+    <ClInclude Include="internal\StringView.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="UaParser.cpp" />
+    <ClCompile Include="internal\Pattern.cpp" />
+    <ClCompile Include="internal\AlternativeExpander.cpp" />
+    <ClCompile Include="internal\SnippetIndex.cpp" />
+    <ClCompile Include="internal\ReplaceTemplate.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/UaParserTest.cpp
+++ b/UaParserTest.cpp
@@ -224,19 +224,19 @@ TEST(DeviceFamily, test_device_mt) {
 }
 #endif  // WITH_MT_TEST
 
-void test_snippets(const std::string& expression, std::vector<std::string> shouldMatch) {
+void test_snippets(const std::string& expression, std::vector<std::string> should_match) {
   uap_cpp::SnippetIndex index;
-  auto snippetSet = index.registerSnippets(expression);
-  auto snippetStringMap = index.getRegisteredSnippets();
+  auto snippet_set = index.registerSnippets(expression);
+  auto snippet_string_map = index.getRegisteredSnippets();
 
-  std::vector<std::string> snippetStrings;
-  for (auto snippetId : snippetSet) {
-    auto it = snippetStringMap.find(snippetId);
-    ASSERT_NE(it, snippetStringMap.end());
-    snippetStrings.emplace_back(it->second);
+  std::vector<std::string> snippet_strings;
+  for (auto snippetId : snippet_set) {
+    auto it = snippet_string_map.find(snippetId);
+    ASSERT_NE(it, snippet_string_map.end());
+    snippet_strings.emplace_back(it->second);
   }
 
-  EXPECT_EQ(snippetStrings, shouldMatch);
+  EXPECT_EQ(snippet_strings, should_match);
 }
 
 TEST(SnippetIndex, snippets) {
@@ -268,8 +268,8 @@ TEST(SnippetIndex, snippets) {
 }
 
 void test_expand(const std::string& expression,
-                 std::vector<std::string> shouldMatch) {
-  EXPECT_EQ(uap_cpp::AlternativeExpander::expand(expression), shouldMatch);
+                 std::vector<std::string> should_match) {
+  EXPECT_EQ(uap_cpp::AlternativeExpander::expand(expression), should_match);
 }
 
 TEST(AlternativeExpander, expansions) {
@@ -302,12 +302,12 @@ TEST(AlternativeExpander, expansions) {
 }
 
 std::string match_and_expand(const std::string& expression,
-                             const std::string& inputString,
-                             const std::string& replaceTemplate) {
+                             const std::string& input_string,
+                             const std::string& replace_template) {
   uap_cpp::Pattern p(expression);
   uap_cpp::Match m;
-  if (p.match(inputString, m)) {
-    return uap_cpp::ReplaceTemplate(replaceTemplate).expand(m);
+  if (p.match(input_string, m)) {
+    return uap_cpp::ReplaceTemplate(replace_template).expand(m);
   }
   return "";
 }

--- a/internal/AlternativeExpander.cpp
+++ b/internal/AlternativeExpander.cpp
@@ -51,7 +51,8 @@ void AlternativeExpander::expand(const StringView& view,
             --level;
           }
         } else if (*s == '[') {
-          const char* closing_parenthesis = get_closing_parenthesis(view.from(s));
+          const char* closing_parenthesis =
+              get_closing_parenthesis(view.from(s));
           if (closing_parenthesis) {
             // Skip character-level alternative block
             s = closing_parenthesis;
@@ -84,7 +85,8 @@ void AlternativeExpander::expand(const StringView& view,
       if (*s == '(') {
         ++level;
         if (level == 1) {
-          const char* closing_parenthesis = get_closing_parenthesis(view.from(s));
+          const char* closing_parenthesis =
+              get_closing_parenthesis(view.from(s));
           if (!closing_parenthesis) {
             // Bad expression
             --level;

--- a/internal/AlternativeExpander.cpp
+++ b/internal/AlternativeExpander.cpp
@@ -15,7 +15,7 @@ std::vector<std::string> AlternativeExpander::expand(
 
 namespace {
 
-bool isNegativeLookaheadOperator(const StringView& view) {
+bool is_negative_lookahead_operator(const StringView& view) {
   const char* s = view.start();
   if (view.isEnd(s) || view.isEnd(s + 1)) {
     return false;
@@ -23,7 +23,7 @@ bool isNegativeLookaheadOperator(const StringView& view) {
   return s[0] == '?' && s[1] == '!';
 }
 
-bool isNonCaptureOperator(const StringView& view) {
+bool is_non_capture_operator(const StringView& view) {
   const char* s = view.start();
   if (view.isEnd(s) || view.isEnd(s + 1)) {
     return false;
@@ -41,9 +41,9 @@ void AlternativeExpander::expand(const StringView& view,
   {
     const char* s = view.start();
     int level = 0;
-    bool prevWasBackslash = false;
+    bool prev_was_backslash = false;
     while (!view.isEnd(s)) {
-      if (!prevWasBackslash) {
+      if (!prev_was_backslash) {
         if (*s == '(') {
           ++level;
         } else if (*s == ')') {
@@ -51,10 +51,10 @@ void AlternativeExpander::expand(const StringView& view,
             --level;
           }
         } else if (*s == '[') {
-          const char* closingParenthesis = getClosingParenthesis(view.from(s));
-          if (closingParenthesis) {
+          const char* closing_parenthesis = get_closing_parenthesis(view.from(s));
+          if (closing_parenthesis) {
             // Skip character-level alternative block
-            s = closingParenthesis;
+            s = closing_parenthesis;
             continue;
           }
         }
@@ -70,7 +70,7 @@ void AlternativeExpander::expand(const StringView& view,
         }
       }
 
-      prevWasBackslash = *s == '\\' && !prevWasBackslash;
+      prev_was_backslash = *s == '\\' && !prev_was_backslash;
       ++s;
     }
   }
@@ -78,38 +78,38 @@ void AlternativeExpander::expand(const StringView& view,
   // Now go through root-level parentheses
   const char* s = view.start();
   int level = 0;
-  bool prevWasBackslash = false;
+  bool prev_was_backslash = false;
   while (!view.isEnd(s)) {
-    if (!prevWasBackslash) {
+    if (!prev_was_backslash) {
       if (*s == '(') {
         ++level;
         if (level == 1) {
-          const char* closingParenthesis = getClosingParenthesis(view.from(s));
-          if (!closingParenthesis) {
+          const char* closing_parenthesis = get_closing_parenthesis(view.from(s));
+          if (!closing_parenthesis) {
             // Bad expression
             --level;
             ++s;
             continue;
           }
 
-          if (isOptionalOperator(view.from(closingParenthesis + 1)) ||
-              isNegativeLookaheadOperator(view.from(s + 1))) {
+          if (is_optional_operator(view.from(closing_parenthesis + 1)) ||
+              is_negative_lookahead_operator(view.from(s + 1))) {
             // Continue after parentheses
-            s = closingParenthesis;
+            s = closing_parenthesis;
             continue;
           }
 
           // Add ( or (?: to prefix
-          const char* innerStart = s + 1;
-          if (isNonCaptureOperator(view.from(innerStart))) {
-            innerStart += 2;
+          const char* inner_start = s + 1;
+          if (is_non_capture_operator(view.from(inner_start))) {
+            inner_start += 2;
           }
-          prefix.append(view.start(), innerStart - view.start());
+          prefix.append(view.start(), inner_start - view.start());
 
-          next.emplace_back(view.from(closingParenthesis));
+          next.emplace_back(view.from(closing_parenthesis));
 
           // Recursively go through what is enclosed by parentheses
-          expand(StringView(innerStart, closingParenthesis),
+          expand(StringView(inner_start, closing_parenthesis),
                  std::move(prefix),
                  std::move(next),
                  out);
@@ -120,16 +120,16 @@ void AlternativeExpander::expand(const StringView& view,
           --level;
         }
       } else if (*s == '[') {
-        const char* closingParenthesis = getClosingParenthesis(view.from(s));
-        if (closingParenthesis) {
+        const char* closing_parenthesis = get_closing_parenthesis(view.from(s));
+        if (closing_parenthesis) {
           // Skip character-level alternative block
-          s = closingParenthesis;
+          s = closing_parenthesis;
           continue;
         }
       }
     }
 
-    prevWasBackslash = *s == '\\' && !prevWasBackslash;
+    prev_was_backslash = *s == '\\' && !prev_was_backslash;
     ++s;
   }
 
@@ -141,10 +141,10 @@ void AlternativeExpander::expand(const StringView& view,
     out.emplace_back(std::move(prefix));
   } else {
     // Pop the stack and continue with rest of string
-    StringView nextView = next.back();
+    StringView next_view = next.back();
     next.pop_back();
 
-    expand(nextView, std::move(prefix), std::move(next), out);
+    expand(next_view, std::move(prefix), std::move(next), out);
   }
 }
 

--- a/internal/AlternativeExpander.cpp
+++ b/internal/AlternativeExpander.cpp
@@ -1,0 +1,151 @@
+#include "AlternativeExpander.h"
+
+#include "StringUtils.h"
+
+namespace uap_cpp {
+
+std::vector<std::string> AlternativeExpander::expand(
+    const StringView& expression) {
+  std::vector<std::string> out;
+  std::string prefix;
+  Stack next;
+  expand(expression, std::move(prefix), std::move(next), out);
+  return out;
+}
+
+namespace {
+
+bool isNegativeLookaheadOperator(const StringView& view) {
+  const char* s = view.start();
+  if (view.isEnd(s) || view.isEnd(s + 1)) {
+    return false;
+  }
+  return s[0] == '?' && s[1] == '!';
+}
+
+bool isNonCaptureOperator(const StringView& view) {
+  const char* s = view.start();
+  if (view.isEnd(s) || view.isEnd(s + 1)) {
+    return false;
+  }
+  return s[0] == '?' && s[1] == ':';
+}
+
+}  // namespace
+
+void AlternativeExpander::expand(const StringView& view,
+                                 std::string prefix,
+                                 Stack next,
+                                 std::vector<std::string>& out) {
+  // First go through root-level alternatives
+  {
+    const char* s = view.start();
+    int level = 0;
+    bool prevWasBackslash = false;
+    while (!view.isEnd(s)) {
+      if (!prevWasBackslash) {
+        if (*s == '(') {
+          ++level;
+        } else if (*s == ')') {
+          if (level > 0) {
+            --level;
+          }
+        } else if (*s == '[') {
+          const char* closingParenthesis = getClosingParenthesis(view.from(s));
+          if (closingParenthesis) {
+            // Skip character-level alternative block
+            s = closingParenthesis;
+            continue;
+          }
+        }
+
+        if (level == 0 && *s == '|') {
+          // Go through alternative on the left
+          expand(view.to(s), prefix, next, out);
+
+          // Go through alternative(s) on the right
+          expand(view.from(s + 1), std::move(prefix), std::move(next), out);
+
+          return;
+        }
+      }
+
+      prevWasBackslash = *s == '\\' && !prevWasBackslash;
+      ++s;
+    }
+  }
+
+  // Now go through root-level parentheses
+  const char* s = view.start();
+  int level = 0;
+  bool prevWasBackslash = false;
+  while (!view.isEnd(s)) {
+    if (!prevWasBackslash) {
+      if (*s == '(') {
+        ++level;
+        if (level == 1) {
+          const char* closingParenthesis = getClosingParenthesis(view.from(s));
+          if (!closingParenthesis) {
+            // Bad expression
+            --level;
+            ++s;
+            continue;
+          }
+
+          if (isOptionalOperator(view.from(closingParenthesis + 1)) ||
+              isNegativeLookaheadOperator(view.from(s + 1))) {
+            // Continue after parentheses
+            s = closingParenthesis;
+            continue;
+          }
+
+          // Add ( or (?: to prefix
+          const char* innerStart = s + 1;
+          if (isNonCaptureOperator(view.from(innerStart))) {
+            innerStart += 2;
+          }
+          prefix.append(view.start(), innerStart - view.start());
+
+          next.emplace_back(view.from(closingParenthesis));
+
+          // Recursively go through what is enclosed by parentheses
+          expand(StringView(innerStart, closingParenthesis),
+                 std::move(prefix),
+                 std::move(next),
+                 out);
+          return;
+        }
+      } else if (*s == ')') {
+        if (level > 0) {
+          --level;
+        }
+      } else if (*s == '[') {
+        const char* closingParenthesis = getClosingParenthesis(view.from(s));
+        if (closingParenthesis) {
+          // Skip character-level alternative block
+          s = closingParenthesis;
+          continue;
+        }
+      }
+    }
+
+    prevWasBackslash = *s == '\\' && !prevWasBackslash;
+    ++s;
+  }
+
+  // No alternatives or parentheses, so add to to prefix
+  prefix.append(view.start(), s - view.start());
+
+  if (next.empty()) {
+    // Reached end of string, add what has been collected
+    out.emplace_back(std::move(prefix));
+  } else {
+    // Pop the stack and continue with rest of string
+    StringView nextView = next.back();
+    next.pop_back();
+
+    expand(nextView, std::move(prefix), std::move(next), out);
+  }
+}
+
+}  // namespace uap_cpp

--- a/internal/AlternativeExpander.h
+++ b/internal/AlternativeExpander.h
@@ -24,7 +24,7 @@ private:
   typedef std::vector<StringView> Stack;
   static void expand(const StringView&,
                      std::string prefix,
-                     Stack nextStack,
+                     Stack next_stack,
                      std::vector<std::string>&);
 };
 

--- a/internal/AlternativeExpander.h
+++ b/internal/AlternativeExpander.h
@@ -20,12 +20,6 @@ namespace uap_cpp {
 class AlternativeExpander {
 public:
   static std::vector<std::string> expand(const StringView& expression);
-private:
-  typedef std::vector<StringView> Stack;
-  static void expand(const StringView&,
-                     std::string prefix,
-                     Stack next_stack,
-                     std::vector<std::string>&);
 };
 
 }

--- a/internal/AlternativeExpander.h
+++ b/internal/AlternativeExpander.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "StringView.h"
+
+#include <string>
+#include <vector>
+
+namespace uap_cpp {
+
+/**
+ * Regular expression preprocessor that expands alternatives into their
+ * possible combinations.
+ *
+ * For example, the expression "(Something|Other)/\d+" will be expanded to the
+ * the expressions "(Something)/\d+" and "(Other)/\d+".
+ *
+ * This allows for a better mapping of mandatory snippets without complicating
+ * the actual indexing implementation.
+ */
+class AlternativeExpander {
+public:
+  static std::vector<std::string> expand(const StringView& expression);
+private:
+  typedef std::vector<StringView> Stack;
+  static void expand(const StringView&,
+                     std::string prefix,
+                     Stack nextStack,
+                     std::vector<std::string>&);
+};
+
+}

--- a/internal/Pattern.cpp
+++ b/internal/Pattern.cpp
@@ -4,19 +4,19 @@ namespace uap_cpp {
 
 Pattern::Pattern() : groupCount_(0) {}
 
-Pattern::Pattern(const std::string& pattern, bool caseSensitive)
+Pattern::Pattern(const std::string& pattern, bool case_sensitive)
     : groupCount_(0) {
-  assign(pattern, caseSensitive);
+  assign(pattern, case_sensitive);
 }
 
-void Pattern::assign(const std::string& pattern, bool caseSensitive) {
+void Pattern::assign(const std::string& pattern, bool case_sensitive) {
   // Add parentheses around expression for capture group 0
-  std::string patternWithZeroGroup = "(" + pattern + ")";
+  std::string pattern_with_zero_group = "(" + pattern + ")";
 
   re2::RE2::Options options;
-  options.set_case_sensitive(caseSensitive);
+  options.set_case_sensitive(case_sensitive);
 
-  regex_ = std::make_unique<re2::RE2>(patternWithZeroGroup, options);
+  regex_ = std::make_unique<re2::RE2>(pattern_with_zero_group, options);
 
   groupCount_ = regex_->NumberOfCapturingGroups();
   if (groupCount_ > Match::MAX_MATCHES) {
@@ -45,12 +45,12 @@ int Match::size() const {
 }
 
 namespace {
-std::string emptyString;
+std::string empty_string;
 }
 
 const std::string& Match::get(int index) const {
   if (index > count_) {
-    return emptyString;
+    return empty_string;
   }
   return strings_[index];
 }

--- a/internal/Pattern.cpp
+++ b/internal/Pattern.cpp
@@ -34,13 +34,13 @@ bool Pattern::match(const std::string& s, Match& m) const {
 }
 
 Match::Match() {
-  for (int i = 0; i < MAX_MATCHES; i++) {
+  for (size_t i = 0; i < MAX_MATCHES; i++) {
     args_[i] = &strings_[i];
     argPtrs_[i] = &args_[i];
   }
 }
 
-int Match::size() const {
+size_t Match::size() const {
   return count_;
 }
 
@@ -48,7 +48,7 @@ namespace {
 std::string empty_string;
 }
 
-const std::string& Match::get(int index) const {
+const std::string& Match::get(size_t index) const {
   if (index > count_) {
     return empty_string;
   }

--- a/internal/Pattern.cpp
+++ b/internal/Pattern.cpp
@@ -1,0 +1,58 @@
+#include "Pattern.h"
+
+namespace uap_cpp {
+
+Pattern::Pattern() : groupCount_(0) {}
+
+Pattern::Pattern(const std::string& pattern, bool caseSensitive)
+    : groupCount_(0) {
+  assign(pattern, caseSensitive);
+}
+
+void Pattern::assign(const std::string& pattern, bool caseSensitive) {
+  // Add parentheses around expression for capture group 0
+  std::string patternWithZeroGroup = "(" + pattern + ")";
+
+  re2::RE2::Options options;
+  options.set_case_sensitive(caseSensitive);
+
+  regex_ = std::make_unique<re2::RE2>(patternWithZeroGroup, options);
+
+  groupCount_ = regex_->NumberOfCapturingGroups();
+  if (groupCount_ > Match::MAX_MATCHES) {
+    groupCount_ = Match::MAX_MATCHES;
+  }
+}
+
+bool Pattern::match(const std::string& s, Match& m) const {
+  if (regex_ && re2::RE2::PartialMatchN(s, *regex_, m.argPtrs_, groupCount_)) {
+    m.count_ = groupCount_;
+    return true;
+  }
+  m.count_ = 0;
+  return false;
+}
+
+Match::Match() {
+  for (int i = 0; i < MAX_MATCHES; i++) {
+    args_[i] = &strings_[i];
+    argPtrs_[i] = &args_[i];
+  }
+}
+
+int Match::size() const {
+  return count_;
+}
+
+namespace {
+std::string emptyString;
+}
+
+const std::string& Match::get(int index) const {
+  if (index > count_) {
+    return emptyString;
+  }
+  return strings_[index];
+}
+
+}  // namespace uap_cpp

--- a/internal/Pattern.h
+++ b/internal/Pattern.h
@@ -22,7 +22,7 @@ class Pattern {
 
  private:
   std::unique_ptr<re2::RE2> regex_;
-  int groupCount_;
+  size_t groupCount_;
 };
 
 /**
@@ -32,8 +32,8 @@ class Match {
  public:
   Match();
 
-  int size() const;
-  const std::string& get(int index) const;
+  size_t size() const;
+  const std::string& get(size_t index) const;
 
  private:
   friend class Pattern;
@@ -41,7 +41,7 @@ class Match {
   std::string strings_[MAX_MATCHES];
   re2::RE2::Arg args_[MAX_MATCHES];
   const re2::RE2::Arg* argPtrs_[MAX_MATCHES];
-  int count_;
+  size_t count_;
 };
 
 }  // namespace uap_cpp

--- a/internal/Pattern.h
+++ b/internal/Pattern.h
@@ -37,7 +37,7 @@ class Match {
 
  private:
   friend class Pattern;
-  enum { MAX_MATCHES = 10 };
+  static constexpr size_t MAX_MATCHES = 10;
   std::string strings_[MAX_MATCHES];
   re2::RE2::Arg args_[MAX_MATCHES];
   const re2::RE2::Arg* argPtrs_[MAX_MATCHES];

--- a/internal/Pattern.h
+++ b/internal/Pattern.h
@@ -14,9 +14,9 @@ class Match;
 class Pattern {
  public:
   Pattern();
-  Pattern(const std::string&, bool caseSensitive = true);
+  Pattern(const std::string&, bool case_sensitive = true);
 
-  void assign(const std::string&, bool caseSensitive = true);
+  void assign(const std::string&, bool case_sensitive = true);
 
   bool match(const std::string&, Match&) const;
 

--- a/internal/Pattern.h
+++ b/internal/Pattern.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <re2/re2.h>
+#include <memory>
+#include <string>
+
+namespace uap_cpp {
+
+class Match;
+
+/**
+ * Wrapper around a re2 regular expression
+ */
+class Pattern {
+ public:
+  Pattern();
+  Pattern(const std::string&, bool caseSensitive = true);
+
+  void assign(const std::string&, bool caseSensitive = true);
+
+  bool match(const std::string&, Match&) const;
+
+ private:
+  std::unique_ptr<re2::RE2> regex_;
+  int groupCount_;
+};
+
+/**
+ * Intended to be used with thread_local to avoid initialization cost
+ */
+class Match {
+ public:
+  Match();
+
+  int size() const;
+  const std::string& get(int index) const;
+
+ private:
+  friend class Pattern;
+  enum { MAX_MATCHES = 10 };
+  std::string strings_[MAX_MATCHES];
+  re2::RE2::Arg args_[MAX_MATCHES];
+  const re2::RE2::Arg* argPtrs_[MAX_MATCHES];
+  int count_;
+};
+
+}  // namespace uap_cpp

--- a/internal/README.md
+++ b/internal/README.md
@@ -1,0 +1,87 @@
+The snippet index adds a preprocessing layer that reduces the number of expressions to loop over, to save processing time. The way expressions are matched does not change, and still uses the `RE2` classes with the same expressions.
+
+The idea for the preprocessing layer is that the expressions contain mandatory snippets of text that need to be present for the expression to match, and these snippets can be indexed in a tree structure that can be used to get the expressions that can possibly match for the input string in question.
+
+```C++
+SnippetIndex index;
+SnippetMapping<int> mapping;
+
+// Register expression 1 (foo.bar)
+{
+  auto snippetIds = index.registerSnippets("foo.bar");
+
+  std::cout << "Expression 1 (foo.bar) needs" << std::endl;
+  for (auto snippetId : snippetIds) {
+    std::cout << " - snippet " << snippetId << std::endl;
+  }
+
+  mapping.addMapping(snippetIds, 1);
+}
+
+// Register expression 2 (foodbar)
+{
+  auto snippetIds = index.registerSnippets("foodbar");
+
+  std::cout << "Expression 2 (foodbar) needs" << std::endl;
+  for (auto snippetId : snippetIds) {
+    std::cout << " - snippet " << snippetId << std::endl;
+  }
+
+  mapping.addMapping(snippetIds, 2);
+}
+
+// Match input strings
+for (auto& inputString : {"barfood", "foobar", "foodbar", "foo"}) {
+  std::cout << "Look up " << inputString << std::endl;
+
+  auto snippetIds = index.getSnippets(inputString);
+  for (auto snippetId : snippetIds) {
+    std::cout << " - Found snippet " << snippetId << std::endl;
+  }
+
+  std::unordered_set<int> expressions;
+  mapping.getExpressions(snippetIds, expressions);
+  if (expressions.empty()) {
+    std::cout << " No expression has all the snippet it needs" << std::endl;
+  } else {
+    for (int expressionId : expressions) {
+      std::cout << " => Expression " << expressionId
+                << " has all the snippets it needs" << std::endl;
+    }
+  }
+}
+```
+
+```
+Expression 1 (foo.bar) needs
+ - snippet 1
+ - snippet 2
+
+Expression 2 (foodbar) needs
+ - snippet 3
+
+Look up barfood
+ - Found snippet 1
+ - Found snippet 2
+ => Expression 1 has all the snippets it needs
+
+Look up foobar
+ - Found snippet 1
+ - Found snippet 2
+ => Expression 1 has all the snippets it needs
+
+Look up foodbar
+ - Found snippet 1
+ - Found snippet 2
+ - Found snippet 3
+ => Expression 2 has all the snippets it needs
+ => Expression 1 has all the snippets it needs
+
+Look up foo
+ - Found snippet 1
+ No expression has all the snippet it needs
+```
+
+Snippet 1 is `foo`, snippet 2 `bar` and snippet 3 `foodbar`. The numbers are assigned in the order the snippets were first found when the expressions were registered.
+
+For simplicity and lookup performance, the order of the snippets in the input does not matter. Remember that this is not a matter of exact matching, but a filter to avoid running unnecessary regular expression matchings.

--- a/internal/ReplaceTemplate.cpp
+++ b/internal/ReplaceTemplate.cpp
@@ -6,26 +6,26 @@ namespace uap_cpp {
 
 ReplaceTemplate::ReplaceTemplate() : approximateSize_(0) {}
 
-ReplaceTemplate::ReplaceTemplate(const std::string& replaceTemplate) {
-  const char* start = replaceTemplate.c_str();
-  const char* chunkStart = start;
+ReplaceTemplate::ReplaceTemplate(const std::string& replace_template) {
+  const char* start = replace_template.c_str();
+  const char* chunk_start = start;
   const char* s = start;
   while (*s) {
     if (s[0] == '$' && '0' <= s[1] && s[1] <= '9') {
       chunks_.push_back(
-          std::string(chunkStart, static_cast<size_t>(s - chunkStart)));
+          std::string(chunk_start, static_cast<size_t>(s - chunk_start)));
       matchIndices_.push_back(static_cast<int>(s[1] - '0'));
 
-      chunkStart = s + 2;
-      s = chunkStart;
+      chunk_start = s + 2;
+      s = chunk_start;
     } else {
       ++s;
     }
   }
   chunks_.push_back(
-      std::string(chunkStart, static_cast<size_t>(s - chunkStart)));
+      std::string(chunk_start, static_cast<size_t>(s - chunk_start)));
 
-  approximateSize_ = replaceTemplate.size() + 15 * (chunks_.size() - 1);
+  approximateSize_ = replace_template.size() + 15 * (chunks_.size() - 1);
 }
 
 bool ReplaceTemplate::empty() const {

--- a/internal/ReplaceTemplate.cpp
+++ b/internal/ReplaceTemplate.cpp
@@ -1,0 +1,59 @@
+#include "ReplaceTemplate.h"
+
+#include "Pattern.h"
+
+namespace uap_cpp {
+
+ReplaceTemplate::ReplaceTemplate() : approximateSize_(0) {}
+
+ReplaceTemplate::ReplaceTemplate(const std::string& replaceTemplate) {
+  const char* start = replaceTemplate.c_str();
+  const char* chunkStart = start;
+  const char* s = start;
+  while (*s) {
+    if (s[0] == '$' && '0' <= s[1] && s[1] <= '9') {
+      chunks_.push_back(
+          std::string(chunkStart, static_cast<size_t>(s - chunkStart)));
+      matchIndices_.push_back(static_cast<int>(s[1] - '0'));
+
+      chunkStart = s + 2;
+      s = chunkStart;
+    } else {
+      ++s;
+    }
+  }
+  chunks_.push_back(
+      std::string(chunkStart, static_cast<size_t>(s - chunkStart)));
+
+  approximateSize_ = replaceTemplate.size() + 15 * (chunks_.size() - 1);
+}
+
+bool ReplaceTemplate::empty() const {
+  return chunks_.empty();
+}
+
+std::string ReplaceTemplate::expand(const Match& m) const {
+  if (chunks_.size() == 1) {
+    return chunks_[0];
+  }
+
+  std::string s;
+  if (approximateSize_ > 0) {
+    s.reserve(approximateSize_);
+  }
+
+  size_t index = 0;
+  for (const auto& chunk : chunks_) {
+    if (index > 0) {
+      s += m.get(matchIndices_[index - 1]);
+    }
+    if (!chunk.empty()) {
+      s += chunk;
+    }
+    ++index;
+  }
+
+  return s;
+}
+
+}  // namespace uap_cpp

--- a/internal/ReplaceTemplate.h
+++ b/internal/ReplaceTemplate.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace uap_cpp {
+
+class Match;
+
+/**
+ * Takes a string with $1, $2, etc, to be replaced by matched blocks
+ */
+class ReplaceTemplate {
+ public:
+  ReplaceTemplate();
+  ReplaceTemplate(const std::string&);
+
+  bool empty() const;
+  std::string expand(const Match&) const;
+
+ private:
+  std::vector<std::string> chunks_;
+  std::vector<int> matchIndices_;
+  size_t approximateSize_;
+};
+
+}  // namespace uap_cpp

--- a/internal/SnippetIndex.cpp
+++ b/internal/SnippetIndex.cpp
@@ -204,9 +204,9 @@ void build_map(const TrieNode& node, const std::string& base_string, Map& map) {
 }
 }  // namespace
 
-std::map<SnippetIndex::SnippetId, std::string>
+std::unordered_map<SnippetIndex::SnippetId, std::string>
 SnippetIndex::getRegisteredSnippets() const {
-  std::map<SnippetId, std::string> map;
+  std::unordered_map<SnippetId, std::string> map;
   build_map(trieRootNode_, "", map);
   return map;
 }

--- a/internal/SnippetIndex.cpp
+++ b/internal/SnippetIndex.cpp
@@ -197,7 +197,7 @@ void build_map(const TrieNode& node, const std::string& base_string, Map& map) {
     auto* next_node = node.transitions_[i];
     if (next_node) {
       std::string next_string(base_string);
-      next_string += (char)i;
+      next_string += static_cast<char>(i);
       build_map(*next_node, next_string, map);
     }
   }

--- a/internal/SnippetIndex.cpp
+++ b/internal/SnippetIndex.cpp
@@ -167,20 +167,20 @@ SnippetIndex::SnippetSet SnippetIndex::getSnippets(
     const StringView& text) const {
   SnippetSet out;
 
-  const char* s = text.start();
-  while (!text.isEnd(s)) {
-    const char* s2 = s;
+  const char* snippet_start = text.start();
+  while (!text.isEnd(snippet_start)) {
+    const char* snippet_end = snippet_start;
     const TrieNode* node = &trieRootNode_;
-    while (node && !text.isEnd(s2)) {
+    while (node && !text.isEnd(snippet_end)) {
       // Every character can be the start of a snippet (actually, only snippet
       // characters, but unconditionally looking it up in the array is faster)
-      node = node->transitions_[to_byte(*s2)];
+      node = node->transitions_[to_byte(*snippet_end)];
       if (node && node->snippetId_) {
         out.insert(node->snippetId_);
       }
-      ++s2;
+      ++snippet_end;
     }
-    ++s;
+    ++snippet_start;
   }
 
   return out;

--- a/internal/SnippetIndex.cpp
+++ b/internal/SnippetIndex.cpp
@@ -1,0 +1,214 @@
+#include "SnippetIndex.h"
+
+#include "StringUtils.h"
+
+namespace uap_cpp {
+
+namespace {
+
+inline bool isSnippetChar(char c, bool prevWasBackslash) {
+  if (('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') ||
+      ('0' <= c && c <= '9')) {
+    // Letters and digits are snippet characters, unless preceded by backslash
+    return !prevWasBackslash;
+  }
+  switch (c) {
+    case ' ':
+    case '_':
+    case '-':
+    case '/':
+    case ',':
+    case ';':
+    case '=':
+    case '%':
+      // These are always snippet characters
+      return true;
+    default:
+      // Other characters are snippet characters if preceded by backslash
+      return prevWasBackslash;
+  }
+}
+
+inline bool possiblySkipBlock(const char*& s, const StringView& view) {
+  if (*s == '(' || *s == '[' || *s == '{') {
+    bool hadAlternativeOperators = false;
+    const char* closingParenthesis =
+        getClosingParenthesis(view.from(s), &hadAlternativeOperators);
+    if (closingParenthesis) {
+      if (*s == '{' || hadAlternativeOperators ||
+          (*s == '(' &&
+           isOptionalOperator(view.from(closingParenthesis + 1)))) {
+        // Always skip count blocks  {1,2}
+        // Skip block with alteratives  (ab|ba) or [ab]
+        // Skip optional block  (a)? (b)* (a){0,}
+        s = closingParenthesis;
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+bool hasRootLevelAlternatives(const StringView& view) {
+  const char* s = view.start();
+
+  bool prevWasBackslash = false;
+  int level = 0;
+  while (!view.isEnd(s)) {
+    if (!prevWasBackslash) {
+      if (*s == '(') {
+        ++level;
+      } else if (*s == ')') {
+        --level;
+      } else if (*s == '|' && level == 0) {
+        return true;
+      } else if (*s == '[') {
+        // Must ignore character-level alternatives  [a(b|c]
+        const char* closingParenthesis = getClosingParenthesis(view.from(s));
+        if (closingParenthesis) {
+          s = closingParenthesis;
+        }
+      }
+    }
+    prevWasBackslash = *s == '\\' && !prevWasBackslash;
+    ++s;
+  }
+  return false;
+}
+
+inline uint8_t toByte(char c, bool toLowercase = true) {
+  uint8_t b = c;
+  // TODO: Duplicate nodes instead of having case-insensitive expressions?
+  if (toLowercase && ('A' <= c && c <= 'Z')) {
+    b |= 0x20;
+  }
+  return b;
+}
+
+}  // namespace
+
+SnippetIndex::SnippetSet SnippetIndex::registerSnippets(
+    const StringView& expression) {
+  SnippetSet out;
+
+  if (hasRootLevelAlternatives(expression)) {
+    // Skip whole expression if alternatives on root level  a|b
+    return out;
+  }
+
+  const char* s = expression.start();
+  const char* snippetStart = nullptr;
+  TrieNode* node = nullptr;
+
+  bool prevWasBackslash = false;
+  while (!expression.isEnd(s)) {
+    if (isSnippetChar(*s, prevWasBackslash)) {
+      if (!node) {
+        snippetStart = s;
+        node = &trieRootNode_;
+      }
+
+      TrieNode*& nextNode = node->transitions_[toByte(*s)];
+      if (!nextNode) {
+        nextNode = new TrieNode;
+        nextNode->parent_ = node;
+      }
+      node = nextNode;
+    } else {
+      if (node) {
+        const char* snippetEnd = s;
+        if (isOptionalOperator(expression.from(snippetEnd))) {
+          // Do not include optional characters  a? a*
+          --snippetEnd;
+          node = node->parent_;
+        }
+
+        registerSnippet(snippetStart, snippetEnd, node, out);
+
+        snippetStart = nullptr;
+        node = nullptr;
+      }
+    }
+
+    if (!prevWasBackslash) {
+      possiblySkipBlock(s, expression);
+    }
+
+    prevWasBackslash = *s == '\\' && !prevWasBackslash;
+    ++s;
+  }
+
+  if (node) {
+    registerSnippet(snippetStart, s, node, out);
+  }
+
+  return out;
+}
+
+void SnippetIndex::registerSnippet(const char* start,
+                                   const char* end,
+                                   TrieNode* node,
+                                   SnippetIndex::SnippetSet& out) {
+  if (node && end - start > 2) {
+    if (!node->snippetId_) {
+      node->snippetId_ = ++maxSnippetId_;
+    }
+    out.insert(node->snippetId_);
+  }
+}
+
+SnippetIndex::TrieNode::~TrieNode() {
+  for (auto* node : transitions_) {
+    delete node;
+  }
+}
+
+SnippetIndex::SnippetSet SnippetIndex::getSnippets(
+    const StringView& text) const {
+  SnippetSet out;
+
+  const char* s = text.start();
+  while (!text.isEnd(s)) {
+    const char* s2 = s;
+    const TrieNode* node = &trieRootNode_;
+    while (node && !text.isEnd(s2)) {
+      // Every character can be the start of a snippet (actually, only snippet
+      // characters, but unconditionally looking it up in the array is faster)
+      node = node->transitions_[toByte(*s2)];
+      if (node && node->snippetId_) {
+        out.insert(node->snippetId_);
+      }
+      ++s2;
+    }
+    ++s;
+  }
+
+  return out;
+}
+
+namespace {
+template <class TrieNode, class Map>
+void buildMap(const TrieNode& node, const std::string& baseString, Map& map) {
+  if (node.snippetId_) {
+    map.insert(std::make_pair(node.snippetId_, baseString));
+  }
+
+  for (int i = 0; i < 256; i++) {
+    auto* nextNode = node.transitions_[i];
+    if (nextNode) {
+      std::string nextString(baseString);
+      nextString += (char)i;
+      buildMap(*nextNode, nextString, map);
+    }
+  }
+}
+}  // namespace
+
+std::map<SnippetIndex::SnippetId, std::string>
+SnippetIndex::getRegisteredSnippets() const {
+  std::map<SnippetId, std::string> map;
+  buildMap(trieRootNode_, "", map);
+  return map;
+}
+
+}  // namespace uap_cpp

--- a/internal/SnippetIndex.h
+++ b/internal/SnippetIndex.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "StringView.h"
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace uap_cpp {
+
+/**
+ * Indexes mandatory snippets in regular expressions.
+ *
+ * For example, in "(a)?(bc)+.* /", "bc" and " /" need to be present in the
+ * input string for the expression to match ("a" is optional, however). This
+ * class handles indexing snippets in expressions, and quickly returning which
+ * snippets are present in an input string.
+ */
+class SnippetIndex {
+ public:
+  typedef uint32_t SnippetId;
+  typedef std::set<SnippetId> SnippetSet;
+
+  SnippetSet registerSnippets(const StringView& expression);
+  SnippetSet getSnippets(const StringView& text) const;
+
+  std::map<SnippetId, std::string> getRegisteredSnippets() const;
+
+ private:
+  struct TrieNode {
+    ~TrieNode();
+    TrieNode* transitions_[256]{nullptr};
+    TrieNode* parent_{nullptr};
+    SnippetId snippetId_{0};
+  };
+  TrieNode trieRootNode_;
+  SnippetId maxSnippetId_{0};
+
+  void registerSnippet(const char* start,
+                       const char* end,
+                       TrieNode*,
+                       SnippetSet&);
+};
+
+}  // namespace uap_cpp

--- a/internal/SnippetIndex.h
+++ b/internal/SnippetIndex.h
@@ -2,9 +2,9 @@
 
 #include "StringView.h"
 
-#include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace uap_cpp {
@@ -25,7 +25,7 @@ class SnippetIndex {
   SnippetSet registerSnippets(const StringView& expression);
   SnippetSet getSnippets(const StringView& text) const;
 
-  std::map<SnippetId, std::string> getRegisteredSnippets() const;
+  std::unordered_map<SnippetId, std::string> getRegisteredSnippets() const;
 
  private:
   struct TrieNode {

--- a/internal/SnippetMapping.h
+++ b/internal/SnippetMapping.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace uap_cpp {
+
+/**
+ * Maps a set of snippets to a set of expressions.
+ */
+template <class Expression>
+class SnippetMapping {
+ public:
+  typedef uint32_t SnippetId;
+
+  /**
+   * Add an expression to the mapping. The snippets all need to be present
+   * for an expression to match. The snippets need to be ordered.
+   */
+  template <class SnippetSet>
+  void addMapping(const SnippetSet& snippets, const Expression& expression) {
+    TrieNode* node = &trieRootNode_;
+    for (SnippetId snippet : snippets) {
+      TrieNode*& slot = node->transitions_[snippet];
+      if (!slot) {
+        slot = new TrieNode;
+      }
+      node = slot;
+    }
+    node->expressions_.insert(expression);
+  }
+
+  /**
+   * Find expressions covered by the found set of snippets. The expressions
+   * should not require a snippet that is not in the matched set of snippets.
+   * The snippet set needs to be ordered the same way as when it was added.
+   */
+  template <class SnippetSet, class Result>
+  void getExpressions(const SnippetSet& snippets, Result& expressions) const {
+    auto end = snippets.end();
+    getExpressionsRecursively(
+        snippets.begin(), end, trieRootNode_, expressions);
+  }
+
+ private:
+  struct TrieNode {
+    ~TrieNode() {
+      for (auto& e : transitions_) {
+        delete e.second;
+      }
+    }
+    std::unordered_map<SnippetId, TrieNode*> transitions_;
+    std::unordered_set<Expression> expressions_;
+  };
+  TrieNode trieRootNode_;
+
+  template <class Iterator, class Result>
+  void getExpressionsRecursively(Iterator it,
+                                 const Iterator& end,
+                                 const TrieNode& node,
+                                 Result& expressions) const {
+    if (!node.expressions_.empty()) {
+      expressions.insert(node.expressions_.begin(), node.expressions_.end());
+    }
+
+    while (it != end) {
+      auto findIt = node.transitions_.find(*it);
+      ++it;
+
+      if (findIt != node.transitions_.end()) {
+        getExpressionsRecursively(it, end, *findIt->second, expressions);
+      }
+    }
+  }
+};
+
+}  // namespace uap_cpp

--- a/internal/SnippetMapping.h
+++ b/internal/SnippetMapping.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -21,11 +22,11 @@ class SnippetMapping {
   void addMapping(const SnippetSet& snippets, const Expression& expression) {
     TrieNode* node = &trieRootNode_;
     for (SnippetId snippet : snippets) {
-      TrieNode*& slot = node->transitions_[snippet];
+      auto& slot = node->transitions_[snippet];
       if (!slot) {
-        slot = new TrieNode;
+        slot = std::make_unique<TrieNode>();
       }
-      node = slot;
+      node = slot.get();
     }
     node->expressions_.insert(expression);
   }
@@ -44,12 +45,7 @@ class SnippetMapping {
 
  private:
   struct TrieNode {
-    ~TrieNode() {
-      for (auto& e : transitions_) {
-        delete e.second;
-      }
-    }
-    std::unordered_map<SnippetId, TrieNode*> transitions_;
+    std::unordered_map<SnippetId, std::unique_ptr<TrieNode>> transitions_;
     std::unordered_set<Expression> expressions_;
   };
   TrieNode trieRootNode_;

--- a/internal/StringUtils.h
+++ b/internal/StringUtils.h
@@ -2,63 +2,63 @@
 
 namespace {
 
-const char* getClosingParenthesis(const uap_cpp::StringView& view,
-                                  bool* hadAlternativeOperators = nullptr) {
-  if (hadAlternativeOperators) {
-    *hadAlternativeOperators = false;
+const char* get_closing_parenthesis(const uap_cpp::StringView& view,
+                                    bool* had_alternative_operators = nullptr) {
+  if (had_alternative_operators) {
+    *had_alternative_operators = false;
   }
 
   const char* s = view.start();
 
-  char startChar = *s;
-  char endChar;
+  char start_char = *s;
+  char end_char;
 
-  bool mayBeNested;
+  bool may_be_nested;
   int level = 0;
-  switch (startChar) {
+  switch (start_char) {
   case '(':
-    endChar = ')';
-    mayBeNested = true;
+    end_char = ')';
+    may_be_nested = true;
     break;
   case '[':
-    endChar = ']';
-    mayBeNested = false;
+    end_char = ']';
+    may_be_nested = false;
     break;
   case '{':
-    endChar = '}';
-    mayBeNested = false;
+    end_char = '}';
+    may_be_nested = false;
     break;
   default:
     return nullptr;
   }
   ++s;
 
-  if (mayBeNested) {
+  if (may_be_nested) {
     ++level;
   }
 
   while (!view.isEnd(s)) {
     if (*s == '\\') {
       ++s;
-    } else if (*s == endChar) {
-      if (mayBeNested) {
+    } else if (*s == end_char) {
+      if (may_be_nested) {
         --level;
       }
       if (level == 0) {
-        if (startChar == '[' && hadAlternativeOperators) {
-          *hadAlternativeOperators = true;
+        if (start_char == '[' && had_alternative_operators) {
+          *had_alternative_operators = true;
         }
-        if (!(startChar == '[' && s - view.start() == 1)) {
+        if (!(start_char == '[' && s - view.start() == 1)) {
           return s;
         }
       }
-    } else if (*s == startChar) {
-      if (mayBeNested) {
+    } else if (*s == start_char) {
+      if (may_be_nested) {
         ++level;
       }
-    } else if (startChar == '(' && *s == '|' && level == 1) {
-      if (hadAlternativeOperators) {
-        *hadAlternativeOperators = true;
+    } else if (start_char == '(' && *s == '|' && level == 1) {
+      if (had_alternative_operators) {
+        *had_alternative_operators = true;
       }
     }
     ++s;
@@ -66,7 +66,7 @@ const char* getClosingParenthesis(const uap_cpp::StringView& view,
   return nullptr;
 }
 
-inline bool isOptionalOperator(const uap_cpp::StringView& view) {
+inline bool is_optional_operator(const uap_cpp::StringView& view) {
   const char* s = view.start();
   if (view.isEnd(s)) {
     return false;

--- a/internal/StringUtils.h
+++ b/internal/StringUtils.h
@@ -1,0 +1,80 @@
+#include "StringView.h"
+
+namespace {
+
+const char* getClosingParenthesis(const uap_cpp::StringView& view,
+                                  bool* hadAlternativeOperators = nullptr) {
+  if (hadAlternativeOperators) {
+    *hadAlternativeOperators = false;
+  }
+
+  const char* s = view.start();
+
+  char startChar = *s;
+  char endChar;
+
+  bool mayBeNested;
+  int level = 0;
+  switch (startChar) {
+  case '(':
+    endChar = ')';
+    mayBeNested = true;
+    break;
+  case '[':
+    endChar = ']';
+    mayBeNested = false;
+    break;
+  case '{':
+    endChar = '}';
+    mayBeNested = false;
+    break;
+  default:
+    return nullptr;
+  }
+  ++s;
+
+  if (mayBeNested) {
+    ++level;
+  }
+
+  while (!view.isEnd(s)) {
+    if (*s == '\\') {
+      ++s;
+    } else if (*s == endChar) {
+      if (mayBeNested) {
+        --level;
+      }
+      if (level == 0) {
+        if (startChar == '[' && hadAlternativeOperators) {
+          *hadAlternativeOperators = true;
+        }
+        if (!(startChar == '[' && s - view.start() == 1)) {
+          return s;
+        }
+      }
+    } else if (*s == startChar) {
+      if (mayBeNested) {
+        ++level;
+      }
+    } else if (startChar == '(' && *s == '|' && level == 1) {
+      if (hadAlternativeOperators) {
+        *hadAlternativeOperators = true;
+      }
+    }
+    ++s;
+  }
+  return nullptr;
+}
+
+inline bool isOptionalOperator(const uap_cpp::StringView& view) {
+  const char* s = view.start();
+  if (view.isEnd(s)) {
+    return false;
+  }
+  if (*s == '{') {
+    return !view.isEnd(s + 1) && (s[1] == '0' || s[1] == ',');
+  }
+  return *s == '*' || *s == '?';
+}
+
+}

--- a/internal/StringUtils.h
+++ b/internal/StringUtils.h
@@ -2,8 +2,22 @@
 
 namespace {
 
-const char* get_closing_parenthesis(const uap_cpp::StringView& view,
-                                    bool* had_alternative_operators = nullptr) {
+inline char get_corresponding_end_char(char start_char) {
+  switch (start_char) {
+    case '(':
+      return ')';
+    case '[':
+      return ']';
+    case '{':
+      return '}';
+    default:
+      return '\0';
+  }
+}
+
+inline const char* get_closing_parenthesis(
+    const uap_cpp::StringView& view,
+    bool* had_alternative_operators = nullptr) {
   if (had_alternative_operators) {
     *had_alternative_operators = false;
   }
@@ -11,28 +25,14 @@ const char* get_closing_parenthesis(const uap_cpp::StringView& view,
   const char* s = view.start();
 
   char start_char = *s;
-  char end_char;
-
-  bool may_be_nested;
-  int level = 0;
-  switch (start_char) {
-  case '(':
-    end_char = ')';
-    may_be_nested = true;
-    break;
-  case '[':
-    end_char = ']';
-    may_be_nested = false;
-    break;
-  case '{':
-    end_char = '}';
-    may_be_nested = false;
-    break;
-  default:
+  char end_char = get_corresponding_end_char(start_char);
+  if (!end_char) {
     return nullptr;
   }
   ++s;
 
+  int level = 0;
+  bool may_be_nested = start_char == '(';
   if (may_be_nested) {
     ++level;
   }
@@ -77,4 +77,4 @@ inline bool is_optional_operator(const uap_cpp::StringView& view) {
   return *s == '*' || *s == '?';
 }
 
-}
+}  // namespace

--- a/internal/StringUtils.h
+++ b/internal/StringUtils.h
@@ -77,4 +77,40 @@ inline bool is_optional_operator(const uap_cpp::StringView& view) {
   return *s == '*' || *s == '?';
 }
 
+inline bool is_whitespace(char ch) {
+  return ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n';
+}
+
+template <class String>
+void trim(String& s) {
+  size_t trim_left = 0;
+  for (auto it = s.begin(); it != s.end(); ++it) {
+    if (!is_whitespace(*it)) {
+      break;
+    }
+    ++trim_left;
+  }
+
+  if (trim_left == s.size()) {
+    s.clear();
+  } else {
+    size_t trim_right = 0;
+    for (auto it = s.rbegin(); it != s.rend(); ++it) {
+      if (!is_whitespace(*it)) {
+        break;
+      }
+      ++trim_right;
+    }
+
+    if (trim_left > 0 || trim_right > 0) {
+      if (trim_left == 0) {
+        s.resize(s.size() - trim_right);
+      } else {
+        String copy(s.c_str() + trim_left, s.size() - trim_left - trim_right);
+        s.swap(copy);
+      }
+    }
+  }
+}
+
 }  // namespace

--- a/internal/StringView.h
+++ b/internal/StringView.h
@@ -1,0 +1,38 @@
+#pragma once
+
+namespace uap_cpp {
+
+class StringView {
+public:
+  template <class String>
+  StringView(const String& s) : start_(s.data()), end_(start_ + s.size()) {
+  }
+
+  StringView(const char* start) : start_(start), end_(nullptr) {
+  }
+
+  StringView(const char* start, const char* end) : start_(start), end_(end) {
+  }
+
+  const char* start() const {
+    return start_;
+  }
+
+  bool isEnd(const char* s) const {
+    return (end_ && s >= end_) || (!end_ && *s == 0);
+  }
+
+  StringView from(const char* start) const {
+    return StringView(start, end_);
+  }
+
+  StringView to(const char* end) const {
+    return StringView(start_, end);
+  }
+
+private:
+  const char* start_;
+  const char* end_;
+};
+
+}


### PR DESCRIPTION
This PR contains changes to address performance issues in the user agent parsing, and stems from a development effort at [Dailymotion](https://www.dailymotion.com/). The external interface has not changed, and it calling it should give the same results, approximately ten times faster (tested with a set of production traffic user agent strings).

The code introduced by this PR is mainly contained within the `internal/` directory, to avoid adding too much clutter to the root directory.

There are two main changes:
* Instead of going through every regex, build an index of text snippets that need to be present for a regex to match, and only call the regexes where this requirement is fulfilled for the given input string. For more details, see [internal/README.md](https://github.com/DailyMats/uap-cpp/blob/index-snippets/internal/README.md).
* Use re2 instead of boost::regex, for better performance. The only thing missing from re2 is negative lookahead (the `(?!)` operator), which is not used in the regexes.yaml file (only internally in the uap-cpp code, where it is easily replaced by a `std::string::find()` call).

A few changes were also made to the `Makefile`, to integrate it more easily into our build system.