### PR TITLE
Use AR make variable to build the static library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ OBJECT_FILES = UaParser.o \
 	internal/ReplaceTemplate.o
 
 libuaparser_cpp.a: $(OBJECT_FILES)
-	ar rcs $@ $^
+	$(AR) rcs $@ $^
 
 libuaparser_cpp.so: $(OBJECT_FILES)
 	$(CXX) $< -shared $(LDFLAGS) -o $@


### PR DESCRIPTION
Explanation: current variant do not allow redefine `AR` variable.