### PR TITLE
Fix a bug while device_type() try to match Android Tablet UA

### DIFF
--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -344,13 +344,13 @@ DeviceType UserAgentParser::device_type(const std::string& ua) noexcept {
       "Accelerated|(hpw|web)OS|Fennec|Minimo|Opera "
       "M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune");
   static const uap_cpp::Pattern rx_tabl(
-      "(tablet|ipad|playbook|silk)|(android?!.*mobile)", false);
+      "(tablet|ipad|playbook|silk)|(android.*)", false);
   thread_local uap_cpp::Match m;
   try {
-    if (rx_tabl.match(ua, m)) {
+    if (rx_tabl.match(ua, m) &&
+        m.get(2).find("Mobile") == std::string::npos) {
       return DeviceType::kTablet;
-    } else if (rx_mob.match(ua, m) &&
-               m.get(2).find("mobile") == std::string::npos) {
+    } else if (rx_mob.match(ua, m)) {
       return DeviceType::kMobile;
     }
     return DeviceType::kDesktop;

--- a/UaParserTest.cpp
+++ b/UaParserTest.cpp
@@ -57,11 +57,17 @@ TEST(UserAgentParser, DeviceTypeMobile) {
 }
 
 TEST(UserAgentParser, DeviceTypeTablet) {
-  ASSERT_TRUE(uap_cpp::UserAgentParser::device_type(
+  EXPECT_TRUE(uap_cpp::UserAgentParser::device_type(
                   "Mozilla/5.0 (Linux; U; en-us; KFTT Build/IML74K) "
                   "AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.0 "
                   "Safari/535.19 Silk-Accelerated=false") ==
               uap_cpp::DeviceType::kTablet);
+  EXPECT_TRUE(
+      uap_cpp::UserAgentParser::device_type(
+          "Mozilla/5.0 (Linux; Android 9; SHT-AL09 Build/HUAWEISHT-AL09; wv) "
+          "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 "
+          "Chrome/79.0.3945.136 Safari/537.36") ==
+      uap_cpp::DeviceType::kTablet);
 }
 
 TEST(UserAgentParser, DeviceTypeDesktop) {


### PR DESCRIPTION
I found that device_type() detects Android Tablet UAstrings as kMobile.
Example: 
```
Mozilla/5.0 (Linux; Android 9; SHT-AL09 Build/HUAWEISHT-AL09; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.136 Safari/537.36
``` 

I think re2 do not support `android?!.*mobile` is the reason.
ref: https://github.com/google/re2/blob/ca11026a032ce2a3de4b3c389ee53d2bdc8794d6/doc/syntax.txt#L83

This PR contains 
-   fix tablet match for Android Tablet
-   remove no-use check for mobile
-   add testcase of Android Tablet