### PR TITLE
Add missing include for integer types (needed for GCC 13)

### DIFF
--- a/internal/SnippetIndex.h
+++ b/internal/SnippetIndex.h
@@ -2,6 +2,7 @@
 
 #include "StringView.h"
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <unordered_map>

--- a/internal/SnippetMapping.h
+++ b/internal/SnippetMapping.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
The current master does not build on Ubuntu 23.10:

```
root@df7042aa9f8f:/uap-cpp# make
g++ -c  -std=c++0x -Wall -Werror -g -fPIC -O3 UaParser.cpp -o UaParser.o
g++ -c  -std=c++0x -Wall -Werror -g -fPIC -O3 internal/Pattern.cpp -o internal/Pattern.o
g++ -c  -std=c++0x -Wall -Werror -g -fPIC -O3 internal/AlternativeExpander.cpp -o internal/AlternativeExpander.o
g++ -c  -std=c++0x -Wall -Werror -g -fPIC -O3 internal/SnippetIndex.cpp -o internal/SnippetIndex.o
In file included from internal/SnippetIndex.cpp:1:
internal/SnippetIndex.h:22:11: error: 'uint32_t' does not name a type
   22 |   typedef uint32_t SnippetId;
      |           ^~~~~~~~
internal/SnippetIndex.h:9:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    8 | #include <vector>
  +++ |+#include <cstdint>
    9 |
```

This PR adds the missing includes.