### PR TITLE
Basic flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "C++ implementation of ua-parser";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      perSystem = { config, self', inputs', pkgs, system, ... }: {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            cmake
+            re2
+            libyamlcpp
+          ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
I've got very little knowledge of this yet, but it does let me
```sh
$ nix develop
$ make bench
```
after adjusting the compiler to C++17 (because I'm getting a version of asbl which requires C++17 and I've no idea how to change that). So seems like a good start, and maybe eventually someone who knows what they're doing can fix it better.