### PR TITLE
build: update the cmake for proper support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,60 +1,103 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.20)
 
-project(uap-cpp)
+project(uap-cpp VERSION 1.0.0 LANGUAGES CXX)
 
-IF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
-    SET(CMAKE_BUILD_TYPE Release)
-ENDIF(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+option(BUILD_SHARED "Build shared library" ON)
+option(BUILD_STATIC "Build static library" ON)
+option(BUILD_BENCHMARKS "Build benchmark executable" OFF)
+option(BUILD_TESTS "Build GoogleTest unit-tests" ON)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -Werror -fPIC")
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
-
-
-
-set(LIB_SOURCES
-        UaParser.cpp
-        internal/AlternativeExpander.cpp
-        internal/Pattern.cpp
-        internal/ReplaceTemplate.cpp
-        internal/SnippetIndex.cpp)
+include(GNUInstallDirs)
 
 find_package(yaml-cpp REQUIRED)
-include_directories(${YAML_CPP_INCLUDE_DIR})
+include(FindPkgConfig)
+pkg_check_modules(re2 REQUIRED IMPORTED_TARGET re2)
 
-find_package(re2)
+if(BUILD_TESTS)
+    enable_testing()
+    find_package(GTest CONFIG REQUIRED)
+endif()
 
-# this is the "object library" target: compiles the sources only once
-add_library(objlib OBJECT ${LIB_SOURCES})
+set(UAP_PUBLIC_HEADERS UaParser)
+file(GLOB INTERNAL_SRCS CONFIGURE_DEPENDS "internal/*.cpp" "internal/*.h")
+set(UAP_SOURCES UaParser.cpp ${INTERNAL_SRCS})
 
-# shared libraries need PIC
-set_property(TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
+add_library(uap_objects OBJECT ${UAP_SOURCES})
+set_target_properties(uap_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-# shared and static libraries built from the same object files
-add_library(uap-cpp-static STATIC $<TARGET_OBJECTS:objlib>)
-set_target_properties(uap-cpp-static PROPERTIES OUTPUT_NAME uaparser_cpp)
+target_include_directories(uap_objects
+    PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/uap-cpp>
+    PRIVATE internal)
 
-add_library(uap-cpp-shared SHARED $<TARGET_OBJECTS:objlib>)
-set_target_properties(uap-cpp-shared PROPERTIES OUTPUT_NAME uaparser_cpp)
+target_link_libraries(uap_objects PUBLIC PkgConfig::re2 yaml-cpp)
+
+set(UAP_BUILT_TARGETS)
+
+if(BUILD_SHARED)
+    add_library(uap-cpp-shared SHARED $<TARGET_OBJECTS:uap_objects>)
+    set_target_properties(uap-cpp-shared PROPERTIES OUTPUT_NAME uaparser_cpp)
+    target_link_libraries(uap-cpp-shared PUBLIC PkgConfig::re2 yaml-cpp)
+    list(APPEND UAP_BUILT_TARGETS uap-cpp-shared)
+endif()
+
+if(BUILD_STATIC)
+    add_library(uap-cpp-static STATIC $<TARGET_OBJECTS:uap_objects>)
+    set_target_properties(uap-cpp-static PROPERTIES
+        OUTPUT_NAME uaparser_cpp
+        POSITION_INDEPENDENT_CODE ON)
+    target_link_libraries(uap-cpp-static PUBLIC PkgConfig::re2 yaml-cpp)
+    list(APPEND UAP_BUILT_TARGETS uap-cpp-static)
+endif()
 
 
+if(BUILD_BENCHMARKS)
+    add_executable(uap-bench benchmarks/UaParserBench.cpp)
+    target_link_libraries(uap-bench PRIVATE uap-cpp-shared pthread)
+endif()
 
-set(TEST_SOURCES
-        UaParserTest.cpp)
+if(BUILD_TESTS)
+    add_executable(uap-cpp-tests UaParserTest.cpp)
+    target_link_libraries(uap-cpp-tests PRIVATE uap-cpp-shared GTest::gtest_main pthread)
+    add_test(NAME UaParserTests COMMAND uap-cpp-tests)
+    install(TARGETS uap-cpp-tests RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 
-find_package(GTest)
+install(TARGETS ${UAP_BUILT_TARGETS}
+    EXPORT  uap_cppTargets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/uap-cpp
+)
 
-add_executable(tests ${TEST_SOURCES} $<TARGET_OBJECTS:objlib>)
-set_target_properties(tests PROPERTIES OUTPUT_NAME UaParserTest)
+include(CMakePackageConfigHelpers)
 
-target_link_libraries(tests re2 yaml-cpp gtest pthread)
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/uap-cppConfigVersion.cmake
+    VERSION       ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
 
+configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/uap-cppConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/uap-cppConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/uap-cpp
+)
 
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/uap-cppConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/uap-cppConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/uap-cpp
+)
 
-set(BENCH_SOURCES
-        benchmarks/UaParserBench.cpp)
-
-add_executable(bench ${BENCH_SOURCES} $<TARGET_OBJECTS:objlib>)
-set_target_properties(bench PROPERTIES OUTPUT_NAME UaParserBench)
-
-target_link_libraries(bench re2 yaml-cpp pthread)
+install(EXPORT uap_cppTargets
+    FILE uap-cppTargets.cmake
+    NAMESPACE uap-cpp::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/uap-cpp
+)

--- a/UaParser
+++ b/UaParser
@@ -33,6 +33,7 @@ struct UserAgent {
 
   Agent os;
   Agent browser;
+  std::string ua_string;
 
   std::string toFullString() const {
     return browser.toString() + "/" + os.toString();

--- a/UaParser.cpp
+++ b/UaParser.cpp
@@ -1,4 +1,4 @@
-#include "UaParser.h"
+#include "UaParser"
 
 #include <yaml-cpp/yaml.h>
 
@@ -307,9 +307,9 @@ UserAgent UserAgentParser::parse(const std::string& ua) const noexcept {
     const auto device = parse_device_impl(ua, ua_store);
     const auto os = parse_os_impl(ua, ua_store);
     const auto browser = parse_browser_impl(ua, ua_store);
-    return {device, os, browser};
+    return {device, os, browser, ua};
   } catch (...) {
-    return {Device(), Agent(), Agent()};
+    return {Device(), Agent(), Agent(), ""};
   }
 }
 

--- a/UaParserTest.cpp
+++ b/UaParserTest.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #include <yaml-cpp/yaml.h>
 
-#include "UaParser.h"
+#include "UaParser"
 #include "internal/AlternativeExpander.h"
 #include "internal/Pattern.h"
 #include "internal/ReplaceTemplate.h"

--- a/uap-cppConfig.cmake.in
+++ b/uap-cppConfig.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+include(FindPkgConfig)
+
+pkg_check_modules(re2 IMPORTED_TARGET re2)
+find_dependency(yaml-cpp CONFIG)
+
+include("${CMAKE_CURRENT_LIST_DIR}/uap-cppTargets.cmake")
+check_required_components(uap-cpp)


### PR DESCRIPTION
1. adds options to build static and shared builds
2. added benchmark and tests executable
3. rename the public header without a .h extension
4. store the user agent string in the structure